### PR TITLE
Fix trailing comment in common.js

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -340,4 +340,4 @@
       if (window.buildPortfolio) run(initSkillPopups);
     });
 
-})();   /* end common.js IIFE */
+})();


### PR DESCRIPTION
## Summary
- remove leftover footer comment in `js/common.js`
- ensure file ends with `})();` followed by newline

## Testing
- `tail -n 5 js/common.js`
