### PR TITLE
Add hero chevrons and portfolio carousel

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -25,6 +25,7 @@
     <div class="wrapper">
       <h1>Let's Connect</h1>
       <p>Interested in leveraging data to solve business problems? Let's discuss how we can collaborate.</p>
+      <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
     </div>
   </section>
 

--- a/contributions.html
+++ b/contributions.html
@@ -29,6 +29,7 @@
     <div class="wrapper">
       <h1>Selected Publications & Reports</h1>
       <p>These public-facing documents feature contributions in data analysis, forecasting, and decision support for the City of Grand Junction.</p>
+      <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
     </div>
   </section>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -104,6 +104,19 @@ p {margin-bottom:1em;font-size:19px}
   flex-direction:column;        /* new */
   align-items:center;           /* new → centres child blocks */
 }
+
+.chevron-hint{
+  position:absolute;
+  bottom:16px;
+  left:50%;
+  transform:translateX(-50%);
+  font-size:32px;
+  color:var(--primary);
+  opacity:.85;
+  pointer-events:none;
+  transition:opacity .4s;
+}
+.chevron-hint.hide{opacity:0;}
 /* ───────────────────────────────────────────────────────────
    5.  BUTTONS
    ─────────────────────────────────────────────────────────── */
@@ -207,6 +220,30 @@ p {margin-bottom:1em;font-size:19px}
   background:color-mix(in srgb,var(--primary) 15%,transparent);color:var(--primary);
   font-size:.75rem;font-weight:600;padding:4px 10px;border-radius:6px;max-width:75%;pointer-events:none
 }
+
+/* ───────────────────────────────────────────────────────────
+   PORTFOLIO CAROUSEL
+   ─────────────────────────────────────────────────────────── */
+.portfolio-carousel{
+  position:relative;
+  height:260px;
+  margin-top:40px;
+}
+.portfolio-carousel .carousel-card{
+  position:absolute;
+  top:0;
+  left:50%;
+  width:260px;
+  transform:translateX(-50%);
+  transition:transform .5s, opacity .5s;
+  opacity:0;
+}
+.portfolio-carousel .carousel-card.active{opacity:1;z-index:3}
+.portfolio-carousel .carousel-card.prev,
+.portfolio-carousel .carousel-card.next{opacity:.7;z-index:2}
+.carousel-dots{display:flex;justify-content:center;gap:8px;margin-top:16px}
+.carousel-dot{width:12px;height:12px;border-radius:50%;background:var(--surface-accent);border:none}
+.carousel-dot.active{background:var(--primary)}
 
 /* ───────────────────────────────────────────────────────────
    9.  MODALS

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
           <a href="portfolio.html"                        class="btn-secondary hero-cta">Portfolio</a>
           <a href="documents/Resume.pdf" target="_blank"  class="btn-secondary hero-cta" download>Resume</a>
         </div>
+        <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
       </div>
     </section>
 

--- a/js/common.js
+++ b/js/common.js
@@ -24,7 +24,10 @@
     initChevronHint();
     initCertTicker();
 
-    if (isPage("portfolio"))     run(window.buildPortfolio);       // called once
+    if (isPage("portfolio")) {
+      run(window.buildPortfolioCarousel);
+      run(window.buildPortfolio);
+    }
     if (isPage("home"))      run(initSkillPopups);      // ← new line
 
   });
@@ -51,19 +54,12 @@
     const chev = $(".chevron-hint");
     if (!chev) return;
 
-    const toggle = () => chev.classList.toggle("hide", window.scrollY > 40);
+    const hero = chev.closest(".hero");
+    const shouldHide = () => hero && hero.getBoundingClientRect().bottom <= 0;
+    const toggle = () => chev.classList.toggle("hide", shouldHide());
     on(window,"scroll", toggle, { passive:true });
+    on(window,"resize", toggle);
     toggle();                               // initial state
-
-    /* click ► scroll to next section */
-    $$(".scroll-indicator").forEach(ind=>{
-      on(ind,"click",()=>{
-        const next = ind.closest(".hero")?.nextElementSibling;
-        (next || window).scrollBy({ top: next ? 0 : window.innerHeight*0.8,
-                                    behavior:"smooth" });
-        ind.classList.add("hidden");
-      });
-    });
   }
 
   /* ╭──────────────────── CERTIFICATION TICKER ─────────────────╮ */

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -333,7 +333,7 @@ window.generateProjectModal = function(p){
           </div>
         </div>
         <div class="modal-half">
-          <p class="header-label">Downloads</p>
+          <p class="header-label">Downloads / Links</p>
           <div class="icon-row">
             ${p.resources.map(r => `
               <a href="${r.url}" target="_blank" title="${r.label}">
@@ -547,6 +547,67 @@ function openModal(id){
   document.addEventListener("keydown", trap);
   modal.addEventListener("click",    clickClose);
 }
+
+/* ────────────────────────────────
+   Featured projects carousel
+   ──────────────────────────────── */
+window.buildPortfolioCarousel = function(){
+  const container = document.getElementById("portfolio-carousel");
+  const dotsWrap  = document.getElementById("carousel-dots");
+  const seeMore   = document.getElementById("see-more");
+  const filters   = document.getElementById("filters");
+  const grid      = document.getElementById("projects");
+  if (!container || !dotsWrap) return;
+
+  const featured = window.PROJECTS.slice(0,5);
+  const cards = featured.map(p=>{
+    const c = document.createElement("div");
+    c.className = "carousel-card";
+    c.innerHTML = `<div class="project-card"><div class="overlay"></div><div class="project-title">${p.title}</div><div class="project-subtitle">${p.subtitle}</div><img src="${p.image}" alt="${p.title}"></div>`;
+    c.addEventListener("click",()=>openModal(p.id));
+    container.appendChild(c);
+    return c;
+  });
+  const dots = featured.map((p,i)=>{
+    const d = document.createElement("button");
+    d.className="carousel-dot";
+    d.setAttribute("aria-label", p.title);
+    d.addEventListener("click",()=>goto(i));
+    dotsWrap.appendChild(d);
+    return d;
+  });
+
+  let index=0, timer;
+  const update=()=>{
+    cards.forEach((c,i)=>{
+      const off=i-index;
+      c.classList.remove("prev","next","active");
+      if(off===0) c.classList.add("active");
+      else if(off===-1) c.classList.add("prev");
+      else if(off===1) c.classList.add("next");
+      c.style.transform=`translateX(${off*280}px) scale(${off===0?1:0.85})`;
+      c.style.opacity=Math.abs(off)<=1? (off===0?1:0.7):0;
+      c.style.pointerEvents=Math.abs(off)<=1?"auto":"none";
+    });
+    dots.forEach((d,i)=>d.classList.toggle("active",i===index));
+  };
+  const goto=i=>{ index=(i+cards.length)%cards.length; update(); };
+  const next=()=>goto(index+1);
+  const start=()=>{ timer=setInterval(next,5000); };
+  const stop=()=>clearInterval(timer);
+  container.addEventListener("mouseenter",stop);
+  container.addEventListener("mouseleave",start);
+  start();
+  update();
+
+  if(filters) filters.classList.add("hide");
+  if(grid)    grid.classList.add("hide");
+  seeMore&&seeMore.addEventListener("click",()=>{
+    document.getElementById("carousel-section")?.classList.add("hide");
+    filters?.classList.remove("hide");
+    grid?.classList.remove("hide");
+  });
+};
 
 
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -36,6 +36,15 @@
     <div class="wrapper">
       <h1>Project Portfolio</h1>
       <p>Each project highlights a real-world challenge, the data-driven approach I used, and measurable outcomes.</p>
+      <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
+    </div>
+  </section>
+
+  <section id="carousel-section" class="reveal" aria-label="Featured projects">
+    <div id="portfolio-carousel" class="portfolio-carousel"></div>
+    <div id="carousel-dots" class="carousel-dots" aria-label="Pagination"></div>
+    <div style="text-align:center;margin-top:20px;">
+      <button id="see-more" class="btn-primary">See More</button>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add decorative chevron hint to all hero sections
- fade chevron once user scrolls past hero
- update project modal heading to "Downloads / Links"
- introduce a featured project carousel with pagination and see-more reveal on portfolio page

## Testing
- `npm test` *(fails: package.json missing)*