### PR TITLE
Fix portfolio carousel visibility

### DIFF
--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -603,7 +603,6 @@ window.buildPortfolioCarousel = function(){
   if(filters) filters.classList.add("hide");
   if(grid)    grid.classList.add("hide");
   seeMore&&seeMore.addEventListener("click",()=>{
-    document.getElementById("carousel-section")?.classList.add("hide");
     filters?.classList.remove("hide");
     grid?.classList.remove("hide");
   });

--- a/portfolio.html
+++ b/portfolio.html
@@ -40,7 +40,7 @@
     </div>
   </section>
 
-  <section id="carousel-section" class="reveal" aria-label="Featured projects">
+  <section id="carousel-section" class="reveal active" aria-label="Featured projects">
     <div id="portfolio-carousel" class="portfolio-carousel"></div>
     <div id="carousel-dots" class="carousel-dots" aria-label="Pagination"></div>
     <div style="text-align:center;margin-top:20px;">


### PR DESCRIPTION
## Summary
- keep the portfolio carousel visible by default
- show more projects without hiding the carousel

## Testing
- `npm --version`