### PR TITLE
Fix filter visibility on portfolio page

### DIFF
--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -509,6 +509,9 @@ function initSeeMore(){
       // expand grid and filters smoothly
       filters.classList.remove("hide");
       grid.classList.remove("hide");
+      // ensure reveal animations don't keep them hidden
+      filters.classList.add("active");
+      grid.classList.add("active");
       const gTarget = grid.scrollHeight;
       const fTarget = filters.scrollHeight;
 


### PR DESCRIPTION
## Summary
- ensure filter and project sections get the `active` class when expanding "See More" so reveal animation doesn't hide them

## Testing
- `npm test` *(fails: could not find package.json)*