### PR TITLE
Fix portfolio gap visibility

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -55,7 +55,7 @@
   </section>
 
   <!-- accent gap -->
-  <section id="carousel-gap" class="hide"></section>
+  <section id="carousel-gap"></section>
 
   <!-- filter buttons -->
   <section class="reveal interest-pad hide" id="filters">


### PR DESCRIPTION
## Summary
- show accent gap between carousel and project filters by default

## Testing
- `git status --short`