### PR TITLE
Add real divider for modal header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -626,14 +626,18 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
 }
 
 /* Divider between Tools and Downloads */
-.modal-half:not(:last-child)::after {
-  content: '';
+.modal-header-details {
+  position: relative;
+}
+
+.modal-divider {
   position: absolute;
-  top: 0;
-  right: 0;
+  left: 50%;
+  top: 20%;
   width: 1px;
-  height: 100%;
+  height: 60%;
   background: color-mix(in srgb, var(--text-light) 12%, transparent);
+  transform: translateX(-50%);
 }
 
 /* =========================================================
@@ -641,6 +645,14 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
    (extends the header visually)
 ========================================================= */
 @media (max-width:768px){
+  .modal-divider {
+    width: 80%;
+    height: 1px;
+    top: 50%;
+    left: 10%;
+    transform: translateY(-50%);
+  }
+
 
   /* ---------- burger ---------- */
   .burger{

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -395,6 +395,7 @@ window.generateProjectModal = function (p) {
             ${p.tools.map(t => `<span class="badge">${t}</span>`).join("")}
           </div>
         </div>
+        <div class="modal-divider" aria-hidden="true"></div>
         <div class="modal-half">
           <p class="header-label">Downloads / Links</p>
           <div class="icon-row">


### PR DESCRIPTION
## Summary
- insert a `modal-divider` element between the "Tools" and "Downloads / Links" sections in the portfolio modal
- style the divider vertically on desktop and horizontally on mobile
- remove old pseudo-element border

## Testing
- `git log -1 --stat`