### PR TITLE
Add more GA4 event tracking

### DIFF
--- a/js/contributions.js
+++ b/js/contributions.js
@@ -206,6 +206,7 @@ function buildContributions(){
     // --- section shell -------------------------------------------------
     const section = document.createElement('section');
     section.className = 'surface-band reveal contrib-section';
+    section.dataset.heading = sec.heading;
 
     const wrap   = document.createElement('div');
     wrap.className = 'wrapper';
@@ -291,6 +292,12 @@ function initContribSeeMore(){
             const isExpanded = btn.dataset.expanded === 'true';
             btn.textContent = isExpanded ? 'See Less' : 'See More';
             cards.slice(1).forEach(c => c.classList.toggle('hide', !isExpanded));
+            if (window.gaEvent) {
+              window.gaEvent('contrib_see_more_toggle', {
+                expanded: isExpanded,
+                section: section.dataset.heading || ''
+              });
+            }
           });
         }
         const isExpanded = btn.dataset.expanded === 'true';

--- a/js/ga4-events.js
+++ b/js/ga4-events.js
@@ -6,6 +6,9 @@
     }
   };
 
+  // expose send so other scripts can trigger custom events
+  window.gaEvent = send;
+
   let projectViews = 0;
   window.trackProjectView = id => {
     projectViews++;
@@ -13,6 +16,11 @@
     if (projectViews === 3) {
       send('multi_project_view', { view_count: 3 });
     }
+  };
+
+  // track when a modal is closed
+  window.trackModalClose = id => {
+    send('modal_close', { project_id: id });
   };
 
   document.addEventListener('DOMContentLoaded', () => {

--- a/js/portfolio.js
+++ b/js/portfolio.js
@@ -879,6 +879,8 @@ function openModal(id){
     document.removeEventListener("keydown", trap);
     modal.removeEventListener("click",  clickClose);
 
+    if (window.trackModalClose) trackModalClose(id);
+
     /* clean the address bar */
     if (pushed){
       history.back();                                    // removes #id


### PR DESCRIPTION
## Summary
- expose a helper `gaEvent` in `ga4-events.js`
- send a `modal_close` GA4 event when users close a portfolio project
- track section for contribution 'See More' events

## Testing
- `npm test` *(fails: could not read `package.json`)*