### PR TITLE
Fix chevron hiding on scroll

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -22,7 +22,7 @@
     initReveal();
     setScrollbarVar();
     setViewportVar();
-    // initChevronHint removed to prevent odd scroll behavior on mobile
+    initChevronHint();
     initCertTicker();
 
     if (isPage("portfolio")) {


### PR DESCRIPTION
## Summary
- enable scroll chevron behavior again by calling `initChevronHint`

## Testing
- `npm test` *(fails: missing `package.json`)*