### PR TITLE
Fix Tableau dashboard layout in modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1084,7 +1084,14 @@ body.menu-open::before{opacity:1;}   /* …until the drawer is open      */
 }
 
 /* only kicks in when the modal-body has .stacked */
-.modal-body.stacked  { flex-direction: column; }
+.modal-body.stacked  {
+  flex-direction: column;
+}
+
+/* ensure Tableau embeds always appear after the text */
+.modal-body.stacked .modal-embed {
+  order: 99;
+}
 
 .modal-embed iframe  {
   width: 100%;


### PR DESCRIPTION
## Summary
- force Tableau modals to stack vertically
- ensure embedded dashboards always appear after project text

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683a88fc1a14832390cba0b55b3ac549