### PR TITLE
Add collapsible contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -25,12 +25,15 @@
     <div class="wrapper">
       <h1>Let's Connect</h1>
       <p>Interested in leveraging data to solve business problems?<br>Let's discuss how we can collaborate.</p>
+        <div class="cta-group">
+          <button id="contact-form-toggle" class="btn-primary hero-cta">Send a Message</button>
+        </div>
     </div>
     <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
   </section>
 
   <section class="surface-band reveal">
-    <div class="wrapper contact-form-wrapper">
+    <div class="wrapper contact-form-wrapper hide" id="contact-form">
       <iframe
         src="https://docs.google.com/forms/d/e/1FAIpQLSfvqG5MVYozqze9tIoDwCZh3i28B-yHXGrzoqUuth3wk3kRhA/viewform?embedded=true"
         loading="lazy"
@@ -58,5 +61,6 @@
 
     <script defer src="js/common.js"></script>
     <script defer src="js/ga4-events.js"></script>
+    <script defer src="js/contact.js"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -355,7 +355,13 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
 .contact-form-wrapper {
   padding: 32px;
   margin-inline: clamp(16px, 5vw, 48px);
+  overflow: hidden;
+  transition: height .45s cubic-bezier(.22,.61,.36,1),
+             padding .45s cubic-bezier(.22,.61,.36,1),
+             opacity .35s ease;
+  will-change: height,padding,opacity;
 }
+.contact-form-wrapper.grid-fade{opacity:0}
 .contact-form-wrapper iframe {
   width: 100%;
   min-height: 900px;

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,56 @@
+(() => {
+  'use strict';
+  function initContactFormToggle() {
+    if (document.body.dataset.page !== 'contact') return;
+    const btn = document.getElementById('contact-form-toggle');
+    const formWrap = document.getElementById('contact-form');
+    if (!btn || !formWrap) return;
+    const pad = parseFloat(getComputedStyle(formWrap).paddingTop) || 32;
+
+    btn.addEventListener('click', () => {
+      const expanded = btn.dataset.expanded === 'true';
+      btn.dataset.expanded = expanded ? 'false' : 'true';
+      btn.textContent = expanded ? 'Send a Message' : 'Hide Form';
+      if (expanded) {
+        const start = formWrap.offsetHeight;
+        formWrap.style.height = `${start}px`;
+        formWrap.classList.add('grid-fade');
+        requestAnimationFrame(() => {
+          formWrap.style.height = '0px';
+          formWrap.style.paddingTop = '0px';
+          formWrap.style.paddingBottom = '0px';
+        });
+        setTimeout(() => {
+          formWrap.classList.add('hide');
+          formWrap.classList.remove('grid-fade');
+          formWrap.style.height = '';
+          formWrap.style.paddingTop = '';
+          formWrap.style.paddingBottom = '';
+        }, 450);
+      } else {
+        formWrap.classList.remove('hide');
+        formWrap.classList.add('active');
+        const target = formWrap.scrollHeight;
+        formWrap.style.height = '0px';
+        formWrap.style.paddingTop = '0px';
+        formWrap.style.paddingBottom = '0px';
+        formWrap.classList.add('grid-fade');
+        requestAnimationFrame(() => {
+          formWrap.style.height = `${target}px`;
+          formWrap.style.paddingTop = `${pad}px`;
+          formWrap.style.paddingBottom = `${pad}px`;
+        });
+        setTimeout(() => {
+          formWrap.classList.remove('grid-fade');
+          formWrap.style.height = '';
+          formWrap.style.paddingTop = '';
+          formWrap.style.paddingBottom = '';
+        }, 450);
+      }
+      if (window.gaEvent) {
+        window.gaEvent('contact_form_toggle', { expanded: !expanded });
+      }
+    });
+  }
+  document.addEventListener('DOMContentLoaded', initContactFormToggle);
+})();


### PR DESCRIPTION
## Summary
- add a hero call‑to‑action that toggles the contact form
- hide the Google Form by default and animate open/close
- implement toggle logic in new `contact.js`

## Testing
- `bash` *(no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_683cadf599d483238d7b22a1a9c26716