### PR TITLE
Add contact form modal

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -25,20 +25,27 @@
     <div class="wrapper">
       <h1>Let's Connect</h1>
       <p>Interested in leveraging data to solve business problems?<br>Let's discuss how we can collaborate.</p>
+        <div class="cta-group">
+          <button id="contact-form-toggle" class="btn-secondary hero-cta">Send a Message</button>
+        </div>
     </div>
     <div class="chevron-hint" aria-hidden="true"><i class="fas fa-chevron-down"></i></div>
   </section>
 
-  <section class="surface-band reveal">
-    <div class="wrapper contact-form-wrapper">
-      <iframe
-        src="https://docs.google.com/forms/d/e/1FAIpQLSfvqG5MVYozqze9tIoDwCZh3i28B-yHXGrzoqUuth3wk3kRhA/viewform?embedded=true"
-        loading="lazy"
-        title="Contact Form">
-        Loading…
-      </iframe>
+  <!-- contact form modal -->
+  <div id="contact-modal" class="modal">
+    <div class="modal-content" tabindex="0">
+      <button class="modal-close" aria-label="Close dialog">&times;</button>
+      <div class="modal-title-strip"><h3 class="modal-title">Send a Message</h3></div>
+      <div class="modal-body">
+        <iframe
+          src="https://docs.google.com/forms/d/e/1FAIpQLSfvqG5MVYozqze9tIoDwCZh3i28B-yHXGrzoqUuth3wk3kRhA/viewform?embedded=true"
+          loading="lazy"
+          title="Contact Form"></iframe>
+      </div>
     </div>
-  </section>
+  </div>
+
 
   <section class="surface-band reveal">
     <div class="wrapper contact-grid contact-big">
@@ -58,5 +65,6 @@
 
     <script defer src="js/common.js"></script>
     <script defer src="js/ga4-events.js"></script>
+    <script defer src="js/contact.js"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -350,13 +350,9 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
 .surface-band.reveal.active .contact-card{animation:focusIn .6s forwards}
 
 /* ───────────────────────────────────────────────────────────
-   12b. CONTACT PAGE – FORM EMBED
+   12b. CONTACT PAGE – FORM MODAL
    ─────────────────────────────────────────────────────────── */
-.contact-form-wrapper {
-  padding: 32px;
-  margin-inline: clamp(16px, 5vw, 48px);
-}
-.contact-form-wrapper iframe {
+#contact-modal iframe {
   width: 100%;
   min-height: 900px;
   border: none;

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,46 @@
+(() => {
+  'use strict';
+  function openContactModal() {
+    const modal = document.getElementById('contact-modal');
+    if (!modal) return;
+    modal.classList.add('active');
+    document.body.classList.add('modal-open');
+    const focusable = modal.querySelectorAll('a,button,[tabindex]:not([tabindex="-1"])');
+    focusable[0]?.focus();
+
+    const trap = e => {
+      if (e.key === 'Escape') { close(); return; }
+      if (e.key !== 'Tab' || !focusable.length) return;
+      const first = focusable[0],
+            last  = focusable[focusable.length - 1];
+      if (e.shiftKey ? document.activeElement === first
+                     : document.activeElement === last) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      }
+    };
+
+    const clickClose = e => {
+      if (e.target.classList.contains('modal') ||
+          e.target.classList.contains('modal-close')) close();
+    };
+
+    const close = () => {
+      modal.classList.remove('active');
+      document.body.classList.remove('modal-open');
+      document.removeEventListener('keydown', trap);
+      modal.removeEventListener('click', clickClose);
+    };
+
+    document.addEventListener('keydown', trap);
+    modal.addEventListener('click', clickClose);
+  }
+
+  function initContactModal() {
+    if (document.body.dataset.page !== 'contact') return;
+    const btn = document.getElementById('contact-form-toggle');
+    if (btn) btn.addEventListener('click', openContactModal);
+  }
+
+  document.addEventListener('DOMContentLoaded', initContactModal);
+})();


### PR DESCRIPTION
## Summary
- hide Google Form inside a modal instead of expanding it
- use a transparent hero button matching the home page style
- adjust CSS for new modal form
- implement modal open/close logic in `contact.js`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683cadf599d483238d7b22a1a9c26716