### PR TITLE
Adjust contact modal scrolling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -41,7 +41,8 @@
         <iframe
           src="https://docs.google.com/forms/d/e/1FAIpQLSfvqG5MVYozqze9tIoDwCZh3i28B-yHXGrzoqUuth3wk3kRhA/viewform?embedded=true"
           loading="lazy"
-          title="Contact Form"></iframe>
+          title="Contact Form"
+          scrolling="no"></iframe>
       </div>
     </div>
   </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -354,7 +354,7 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
    ─────────────────────────────────────────────────────────── */
 #contact-modal iframe {
   width: 100%;
-  min-height: 900px;
+  height: 1600px; /* enough height so the Google Form doesn't scroll */
   border: none;
   display: block;
 }


### PR DESCRIPTION
## Summary
- disable iframe scrollbar in contact modal by making the iframe taller and turning off its scrollbars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cb5b601608323b08b8d8f982dea6d