### PR TITLE
Fix mobile contact spacing and dynamic modal height

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -328,6 +328,10 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
   display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
   gap:28px;padding:32px
 }
+
+@media (max-width:768px){
+  .contact-big{padding:0}
+}
 .contact-big .contact-card{padding:32px}
 .contact-card i{font-size:38px}
 
@@ -354,9 +358,9 @@ body.modal-open{overflow:hidden;padding-right:var(--scrollbar,0px)}
    ─────────────────────────────────────────────────────────── */
 #contact-modal iframe {
   width: 100%;
-  height: 1600px; /* enough height so the Google Form doesn't scroll */
   border: none;
   display: block;
+  height: 100%;
 }
 /* match the width of project modals */
 #contact-modal .modal-content {

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,8 +1,27 @@
 (() => {
   'use strict';
+
+  function setContactModalHeight() {
+    const modal = document.getElementById('contact-modal');
+    if (!modal) return;
+    const content = modal.querySelector('.modal-content');
+    const body    = modal.querySelector('.modal-body');
+    const iframe  = modal.querySelector('iframe');
+    const header  = modal.querySelector('.modal-title-strip');
+    if (!content || !body || !iframe || !header) return;
+
+    const bodyStyles = getComputedStyle(body);
+    const padding = parseFloat(bodyStyles.paddingTop) + parseFloat(bodyStyles.paddingBottom);
+    const chrome  = header.getBoundingClientRect().height + padding;
+
+    const max = window.innerHeight * 0.82;
+    iframe.style.height = `${Math.max(0, max - chrome)}px`;
+    if (content) content.style.maxHeight = `${max}px`;
+  }
   function openContactModal() {
     const modal = document.getElementById('contact-modal');
     if (!modal) return;
+    setContactModalHeight();
     modal.classList.add('active');
     document.body.classList.add('modal-open');
     const focusable = modal.querySelectorAll('a,button,[tabindex]:not([tabindex="-1"])');
@@ -40,6 +59,8 @@
     if (document.body.dataset.page !== 'contact') return;
     const btn = document.getElementById('contact-form-toggle');
     if (btn) btn.addEventListener('click', openContactModal);
+    window.addEventListener('resize', setContactModalHeight);
+    setContactModalHeight();
   }
 
   document.addEventListener('DOMContentLoaded', initContactModal);


### PR DESCRIPTION
## Summary
- adjust contact grid padding on small screens to remove double margins
- let contact form iframe use full modal height
- compute modal dimensions based on viewport size

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683cbe59bfa8832383c4a602c2ae81d9