### PR TITLE
Fix modal padding and iframe height

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -41,8 +41,7 @@
         <iframe
           src="https://docs.google.com/forms/d/e/1FAIpQLSfvqG5MVYozqze9tIoDwCZh3i28B-yHXGrzoqUuth3wk3kRhA/viewform?embedded=true"
           loading="lazy"
-          title="Contact Form"
-          scrolling="no"></iframe>
+          title="Contact Form"></iframe>
       </div>
     </div>
   </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1201,3 +1201,10 @@ body.menu-open::before{opacity:1;}   /* …until the drawer is open      */
     transform: none;
   }
 }
+
+@media (max-width: 768px) {
+  /* tighter modal padding on small screens */
+  .modal-body {
+    padding: 4px !important;
+  }
+}

--- a/js/contact.js
+++ b/js/contact.js
@@ -11,11 +11,23 @@
     if (!content || !body || !iframe || !header) return;
 
     const bodyStyles = getComputedStyle(body);
-    const padding = parseFloat(bodyStyles.paddingTop) + parseFloat(bodyStyles.paddingBottom);
-    const chrome  = header.getBoundingClientRect().height + padding;
+    const padding =
+      parseFloat(bodyStyles.paddingTop) + parseFloat(bodyStyles.paddingBottom);
+    const chrome = header.getBoundingClientRect().height + padding;
 
     const max = window.innerHeight * 0.82;
-    iframe.style.height = `${Math.max(0, max - chrome)}px`;
+
+    let iframeHeight = 0;
+    try {
+      const doc = iframe.contentDocument || iframe.contentWindow.document;
+      iframeHeight = doc.documentElement.scrollHeight;
+    } catch (err) {
+      iframeHeight = 0;
+    }
+
+    if (!iframeHeight) iframeHeight = max - chrome;
+    iframe.style.height = `${Math.min(iframeHeight, max - chrome)}px`;
+
     if (content) content.style.maxHeight = `${max}px`;
   }
   function openContactModal() {


### PR DESCRIPTION
## Summary
- tune padding in `.modal-body` on small screens
- allow scrolling for the contact form iframe and try to size it dynamically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cd2f8cf308323af9a1e39460530b8