### PR TITLE
Add accessibility & SEO fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,11 +8,15 @@
   <meta property="og:title" content="404 │ Daniel Short">
   <meta property="og:description" content="The page you requested could not be found.">
   <meta property="og:url" content="https://danielshort.me/404.html">
+  <meta property="og:image" content="img/hero/head.jpg">
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body class="surface-band" style="text-align:center;padding:4rem 1rem;">
-  <h1>404 – Page Not Found</h1>
-  <p>Sorry, the page you were looking for doesn&rsquo;t exist.</p>
-  <p><a href="index.html">Return to home page</a></p>
+  <a href="#main" class="skip-link">Skip to main content</a>
+  <main id="main">
+    <h1>404 – Page Not Found</h1>
+    <p>Sorry, the page you were looking for doesn&rsquo;t exist.</p>
+    <p><a href="index.html">Return to home page</a></p>
+  </main>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Contact │ Daniel Short">
   <meta property="og:description" content="Get in touch with Daniel Short — data analyst &amp; machine-learning practitioner.">
   <meta property="og:url" content="https://danielshort.me/contact.html">
+  <meta property="og:image" content="img/hero/head.jpg">
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
@@ -22,9 +23,10 @@
   <meta name="description" content="Get in touch with Daniel Short — data analyst & machine-learning practitioner.">
 </head>
 <body data-page="contact" class="contact-page">
-
+  <a href="#main" class="skip-link">Skip to main content</a>
   <header id="combined-header-nav"></header>
 
+  <main id="main">
   <section class="hero alt-band">
     <div class="wrapper">
       <h1>Let's Connect</h1>
@@ -65,6 +67,7 @@
       </div>
     </section>
 
+  </main>
   <footer></footer>
 
     <script defer src="js/common/common.js"></script>

--- a/contributions.html
+++ b/contributions.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Contributions │ Daniel Short">
   <meta property="og:description" content="Public-facing reports and publications featuring Daniel Short’s data work for Visit Grand Junction.">
   <meta property="og:url" content="https://danielshort.me/contributions.html">
+  <meta property="og:image" content="img/hero/head.jpg">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
@@ -24,6 +25,7 @@
 
 <!-- give the body an ID so common.js can still inject nav/footer -->
 <body data-page="contributions" class="contributions-page">
+  <a href="#main" class="skip-link">Skip to main content</a>
   <header id="combined-header-nav"></header>
 
   <!-- Hero -->
@@ -36,7 +38,9 @@
   </section>
 
   <!-- Dynamic sections build themselves here -->
-  <main id="contrib-root"></main>
+  <main id="main">
+    <div id="contrib-root"></div>
+  </main>
 
   <footer></footer>
   <script defer src="js/contributions/contributions-data.js"></script>

--- a/css/styles.css
+++ b/css/styles.css
@@ -12,3 +12,5 @@
 @import url("utilities/helpers.css");
 @import url("utilities/typography.css");
 @import url("utilities/colors.css");
+@import url("utilities/accessibility.css");
+@import url("utilities/color-fallback.css");

--- a/css/utilities/accessibility.css
+++ b/css/utilities/accessibility.css
@@ -1,0 +1,19 @@
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  width: auto;
+  height: auto;
+  padding: 8px 12px;
+  background: #fff;
+  color: #000;
+  z-index: 1000;
+}

--- a/css/utilities/color-fallback.css
+++ b/css/utilities/color-fallback.css
@@ -1,0 +1,8 @@
+@supports not (color: color-mix(in srgb, black, white)) {
+  .project-metric { background: rgba(44, 169, 188, 0.15); }
+  .hero { background: rgba(22, 27, 34, 0.5); }
+  .modal { background: rgba(13, 17, 23, 0.88); }
+  .modal-content {
+    box-shadow: 0 10px 28px rgba(13,17,23,0.6), 0 0 0 1px rgba(44,169,188,0.15);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Daniel Short │ Data &amp; Insights">
   <meta property="og:description" content="Daniel Short — data analyst transforming raw numbers into actionable insights.">
   <meta property="og:url" content="https://danielshort.me/">
+  <meta property="og:image" content="img/hero/head.jpg">
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
@@ -34,9 +35,10 @@
   </script>
 </head>
 <body data-page="home">
+  <a href="#main" class="skip-link">Skip to main content</a>
   <header id="combined-header-nav"></header>
 
-  <main>
+  <main id="main">
     <!-- Hero -->
     <section class="hero">
 
@@ -67,17 +69,17 @@
     <section class="cert-band surface-band no-reveal">
       <div class="cert-track">
         <a class="cert" href="https://www.credential.net/0f4df6f1-112e-4e4e-8cb1-b97e7ecd3a3b" target="_blank" rel="noopener">
-          <img src="img/cert_logos/purdue_global.png" alt="Purdue"><span>Bachelor's of Science – Data Analytics</span></a>
+          <img src="img/cert_logos/purdue_global.png" alt="Purdue University logo" loading="lazy"><span>Bachelor's of Science – Data Analytics</span></a>
         <span class="cert">
-          <img src="img/cert_logos/eastern.png" alt="Eastern"><span>Master's of Science – Data Science (May 2025)</span></span>
+          <img src="img/cert_logos/eastern.png" alt="Eastern University logo" loading="lazy"><span>Master's of Science – Data Science (May 2025)</span></span>
         <a class="cert" href="https://www.coursera.org/account/accomplishments/specialization/certificate/CYUMPN7ZQRDA" target="_blank" rel="noopener">
-          <img src="img/cert_logos/ibm.png" alt="IBM"><span>IBM Data Analyst Certification</span></a>
+          <img src="img/cert_logos/ibm.png" alt="IBM logo" loading="lazy"><span>IBM Data Analyst Certification</span></a>
         <a class="cert" href="https://www.coursera.org/account/accomplishments/specialization/certificate/7262X6HH5NF2" target="_blank" rel="noopener">
-          <img src="img/cert_logos/ibm.png" alt="IBM"><span>IBM Machine Learning Certification</span></a>
+          <img src="img/cert_logos/ibm.png" alt="IBM logo" loading="lazy"><span>IBM Machine Learning Certification</span></a>
         <a class="cert" href="https://www.coursera.org/account/accomplishments/specialization/certificate/N6MNKYE4MKEP" target="_blank" rel="noopener">
-          <img src="img/cert_logos/google.png" alt="Google"><span>Google Data Analytics Certification</span></a>
+          <img src="img/cert_logos/google.png" alt="Google logo" loading="lazy"><span>Google Data Analytics Certification</span></a>
         <a class="cert" href="https://www.coursera.org/account/accomplishments/specialization/certificate/K47AGB33F8VS" target="_blank" rel="noopener">
-          <img src="img/cert_logos/google.png" alt="Google"><span>Google Advanced Data Analytics Certification</span></a>
+          <img src="img/cert_logos/google.png" alt="Google logo" loading="lazy"><span>Google Advanced Data Analytics Certification</span></a>
       </div>
     </section>
 

--- a/js/navigation/navigation.js
+++ b/js/navigation/navigation.js
@@ -29,13 +29,13 @@
           <button id="nav-toggle" class="burger" aria-label="Toggle navigation" aria-expanded="false">
             <span class="bar"></span><span class="bar"></span><span class="bar"></span>
           </button>
-          <nav class="nav-row" data-collapsible>
+          <div class="nav-row" data-collapsible role="navigation">
             <a href="index.html" class="btn-secondary nav-link">Home</a>
             <a href="portfolio.html" class="btn-secondary nav-link">Portfolio</a>
             <a href="contributions.html" class="btn-secondary nav-link">Contributions</a>
             <a href="contact.html" class="btn-secondary nav-link">Contact</a>
             <a href="documents/Resume.pdf" class="btn-secondary nav-link" target="_blank" rel="noopener" download>Resume</a>
-          </nav>
+          </div>
         </div>
       </nav>`;
     const cur = location.pathname.split('/').pop() || 'index.html';

--- a/portfolio.html
+++ b/portfolio.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Portfolio │ Daniel Short">
   <meta property="og:description" content="Curated portfolio of data-analytics, ML, and visualization projects by Daniel Short.">
   <meta property="og:url" content="https://danielshort.me/portfolio.html">
+  <meta property="og:image" content="img/hero/head.jpg">
 
   <!-- GA-4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
@@ -28,10 +29,12 @@
 </head>
 
 <body data-page="portfolio">
+  <a href="#main" class="skip-link">Skip to main content</a>
 
   <!-- nav is injected by common.js -->
   <header id="combined-header-nav"></header>
 
+  <main id="main">
   <!-- hero -->
   <section class="hero">
     <div class="wrapper">
@@ -77,6 +80,7 @@
   <div id="modals"></div>
 
   <!-- footer is injected by common.js -->
+  </main>
   <footer></footer>
 
   <!-- scripts -->

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.danielshort.me/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.danielshort.me/index.html</loc>
+  </url>
+  <url>
+    <loc>https://www.danielshort.me/portfolio.html</loc>
+  </url>
+  <url>
+    <loc>https://www.danielshort.me/contributions.html</loc>
+  </url>
+  <url>
+    <loc>https://www.danielshort.me/contact.html</loc>
+  </url>
+</urlset>

--- a/test.js
+++ b/test.js
@@ -51,10 +51,17 @@ function evalScript(file) {
 try {
   // HTML checks across pages
   checkFileContains('index.html', 'Turning data into actionable insights');
-  checkFileContains('contact.html', '<title>Contact │ Daniel Short');
-  ['index.html','contact.html','portfolio.html','contributions.html'].forEach(f => {
-    checkFileContains(f, 'js/common/common.js');
-  });
+checkFileContains('contact.html', '<title>Contact │ Daniel Short');
+['index.html','contact.html','portfolio.html','contributions.html'].forEach(f => {
+  checkFileContains(f, 'js/common/common.js');
+  checkFileContains(f, 'class="skip-link"');
+  checkFileContains(f, '<main id="main">');
+});
+['index.html','contact.html','portfolio.html','contributions.html','404.html'].forEach(f => {
+  checkFileContains(f, 'og:image');
+});
+assert(fs.existsSync('robots.txt'), 'robots.txt missing');
+assert(fs.existsSync('sitemap.xml'), 'sitemap.xml missing');
 
   // Data files expose arrays
   let env = evalScript('js/portfolio/projects-data.js');
@@ -70,6 +77,7 @@ try {
   assert(typeof env.window.gaEvent === 'function', 'ga4-events.js missing gaEvent');
   assert(typeof env.window.trackProjectView === 'function', 'ga4-events.js missing trackProjectView');
   assert(typeof env.window.trackModalClose === 'function', 'ga4-events.js missing trackModalClose');
+  checkFileContains('js/navigation/navigation.js', 'div class="nav-row"');
 
   // Core scripts should load without throwing
   [


### PR DESCRIPTION
## Summary
- add skip links and wrap pages in `<main>` regions
- include og:image meta tags
- add robots.txt and sitemap
- improve certification alt text and lazy loading
- provide color-mix fallbacks
- inject nav row using a `<div>` instead of nested `<nav>`
- extend tests to cover new accessibility and SEO features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e434d7b148323bbf8570a4a94ef4f