### PR TITLE
Add AWS Lambda shape classifier demo

### DIFF
--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -2,13 +2,21 @@
 
 window.generateProjectModal = function (p) {
   const isTableau = p.embed?.type === "tableau";
+  const isIframe  = p.embed?.type === "iframe";
 
   /* helper – which Tableau layout should load right now? */
   const tableauDevice = () =>
     window.matchMedia("(max-width:768px)").matches ? "phone" : "desktop";
 
-  /* build the right-hand visual (image or Tableau iframe) */
+  /* build the right-hand visual (image, iframe, or Tableau) */
   const visual = (() => {
+    if (isIframe) {
+      return `
+        <div class="modal-embed">
+          <iframe src="${p.embed.url}" loading="lazy"></iframe>
+        </div>`;
+    }
+
     if (!isTableau) {
       return `
         <div class="modal-image">

--- a/js/portfolio/projects-data.js
+++ b/js/portfolio/projects-data.js
@@ -337,7 +337,7 @@ window.PROJECTS = [
       "Website and content confirmed selection for my current employment."
     ],
   },
-    {
+  {
     id: "chatbotLora",
     title: "Chatbot (LoRA + RAG)",
     subtitle: "Lite RAG + LoRA Chatbot",
@@ -353,6 +353,29 @@ window.PROJECTS = [
     ],
     results : [
       "Responsive chatbot stays current with our content and engages potential guests."
+    ]
+  },
+
+  {
+    id: "shapeClassifier",
+    title: "Shape Classifier Demo",
+    subtitle: "AWS Lambda Inference",
+    image: "img/projects/project_16.png",
+    tools: ["JavaScript", "AWS"],
+    resources: [
+      { icon: "img/icons/website-icon.png", url: "shape-demo.html", label: "Demo" }
+    ],
+    embed : {
+      type : "iframe",
+      url  : "shape-demo.html"
+    },
+    problem : "Needed a quick way to showcase serverless ML predictions from the browser.",
+    actions : [
+      "Built a drawing canvas that posts the image to a Lambda endpoint.",
+      "Displayed the prediction result right in the modal."
+    ],
+    results : [
+      "Demo illustrates Lambda's speed with responses in about a second."
     ]
   },
 

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shape Classifier Demo</title>
+<style>
+  body   { font-family: sans-serif; text-align: center; margin: 2rem; }
+  canvas { border: 2px solid #444; touch-action: none; }
+  #buttons { margin-top: 1rem; }
+  button { margin: 0 .3rem; padding: .4rem 1rem; font-size: 1rem; }
+  #result { margin-top: 1rem; font-size: 1.2rem; }
+</style>
+</head>
+<body>
+
+<h2>Draw a shape!</h2>
+<canvas id="pad" width="256" height="256"></canvas>
+
+<div id="buttons">
+  <button id="clear">Clear</button>
+  <button id="classify">Classify</button>
+</div>
+
+<div id="result"></div>
+
+<script type="module">
+const FN_URL = "https://zcosyfxhs3sntpwzo3qayki2he0kdxkw.lambda-url.us-east-2.on.aws/";   // update with your endpoint
+
+// ---------- simple drawing pad ----------
+const canvas = document.getElementById("pad");
+const ctx     = canvas.getContext("2d", { willReadFrequently: true });
+
+ctx.lineWidth = 18;
+ctx.lineCap   = "round";
+resetCanvas();
+
+function resetCanvas() {
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = "black";
+}
+document.getElementById("clear").onclick = () => { resetCanvas(); draw = false; };
+
+let draw = false;
+const pos = e => {
+  const r = canvas.getBoundingClientRect();
+  return [ (e.touches ? e.touches[0].clientX : e.clientX) - r.left,
+           (e.touches ? e.touches[0].clientY : e.clientY) - r.top ];
+};
+
+canvas.addEventListener("pointerdown", e => { draw = true; ctx.beginPath(); ctx.moveTo(...pos(e)); });
+canvas.addEventListener("pointermove", e => { if (draw) { ctx.lineTo(...pos(e)); ctx.stroke(); }});
+["pointerup","pointerleave","pointercancel"].forEach(evt => canvas.addEventListener(evt, () => draw = false));
+
+// ---------- classify button ----------
+document.getElementById("classify").onclick = async () => {
+  document.getElementById("result").textContent = "…predicting";
+  const blob = await new Promise(res => canvas.toBlob(res, "image/png"));
+  const b64  = await blob.arrayBuffer().then(buf => btoa(String.fromCharCode(...new Uint8Array(buf))));
+
+  try {
+    const res   = await fetch(FN_URL, {
+      method : "POST",
+      headers: { "Content-Type": "application/json" },
+      body   : JSON.stringify({ b64 })
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const {class: cls, confidence} = await res.json();
+    document.getElementById("result").textContent =
+        `Prediction: ${cls} (${(confidence*100).toFixed(1)} %)`;
+  } catch (err) {
+    document.getElementById("result").textContent = "Error: " + err;
+  }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add shape-demo.html showing how to call a Lambda endpoint from a canvas drawing
- include shape classifier project entry and image placeholder
- allow generic iframe embeds in project modals
- remove placeholder image and set demo URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ac88f07548323bbdb348106d00b5e