### PR TITLE
Update shape classifier demo UI

### DIFF
--- a/shape-demo.html
+++ b/shape-demo.html
@@ -3,12 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <title>Shape Classifier Demo</title>
+<link rel="stylesheet" href="css/styles.css">
 <style>
-  body   { font-family: sans-serif; text-align: center; margin: 2rem; }
-  canvas { border: 2px solid #444; touch-action: none; }
+  html, body { height: auto; }
+  body { text-align: center; margin: 0; }
+  canvas { border: 2px solid #444; touch-action: none; background: #000; }
   #buttons { margin-top: 1rem; }
   button { margin: 0 .3rem; padding: .4rem 1rem; font-size: 1rem; }
-  #result { margin-top: 1rem; font-size: 1.2rem; }
+  #result { margin-top: 1rem; font-size: 1.2rem; min-height: 1.4em; }
+  #result.loading { animation: pulse 1s infinite; opacity: 0.6; }
+  @keyframes pulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }
 </style>
 </head>
 <body>
@@ -21,7 +25,7 @@
   <button id="classify">Classify</button>
 </div>
 
-<div id="result"></div>
+<div id="result" class="modal-text"></div>
 
 <script type="module">
 const FN_URL = "https://zcosyfxhs3sntpwzo3qayki2he0kdxkw.lambda-url.us-east-2.on.aws/";   // Lambda endpoint with CORS
@@ -29,17 +33,20 @@ const FN_URL = "https://zcosyfxhs3sntpwzo3qayki2he0kdxkw.lambda-url.us-east-2.on
 // ---------- simple drawing pad ----------
 const canvas = document.getElementById("pad");
 const ctx     = canvas.getContext("2d", { willReadFrequently: true });
+const clearBtn = document.getElementById("clear");
+const classifyBtn = document.getElementById("classify");
+const resultEl = document.getElementById("result");
 
-ctx.lineWidth = 18;
+ctx.lineWidth = 6;
 ctx.lineCap   = "round";
 resetCanvas();
 
 function resetCanvas() {
-  ctx.fillStyle = "white";
+  ctx.fillStyle = "black";
   ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.strokeStyle = "black";
+  ctx.strokeStyle = "white";
 }
-document.getElementById("clear").onclick = () => { resetCanvas(); draw = false; };
+clearBtn.onclick = () => { resetCanvas(); draw = false; };
 
 let draw = false;
 const pos = e => {
@@ -53,8 +60,11 @@ canvas.addEventListener("pointermove", e => { if (draw) { ctx.lineTo(...pos(e));
 ["pointerup","pointerleave","pointercancel"].forEach(evt => canvas.addEventListener(evt, () => draw = false));
 
 // ---------- classify button ----------
-document.getElementById("classify").onclick = async () => {
-  document.getElementById("result").textContent = "…predicting";
+classifyBtn.onclick = async () => {
+  resultEl.textContent = "Predicting...";
+  resultEl.classList.add("loading");
+  clearBtn.disabled = true;
+  classifyBtn.disabled = true;
   const blob = await new Promise(res => canvas.toBlob(res, "image/png"));
   const b64  = await blob.arrayBuffer().then(buf => btoa(String.fromCharCode(...new Uint8Array(buf))));
 
@@ -66,10 +76,14 @@ document.getElementById("classify").onclick = async () => {
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const {class: cls, confidence} = await res.json();
-    document.getElementById("result").textContent =
+    resultEl.textContent =
         `Prediction: ${cls} (${(confidence*100).toFixed(1)} %)`;
   } catch (err) {
-    document.getElementById("result").textContent = "Error: " + err;
+    resultEl.textContent = "Error: " + err;
+  } finally {
+    resultEl.classList.remove("loading");
+    clearBtn.disabled = false;
+    classifyBtn.disabled = false;
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- restyle the drawing demo to match site modal theme
- use black canvas with a thinner pen
- prevent scrolling and block buttons while predicting
- show a pulsing animation during classification
- fix bottom of frame being cut off so the modal can scroll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ad678ce78832395aadfda70f10d56