### PR TITLE
Update shape classifier layout

### DIFF
--- a/css/utilities/layout.css
+++ b/css/utilities/layout.css
@@ -77,6 +77,20 @@
 }
 
 /* ───────────────────────────────────────────────────────────
+   12c. SHAPE CLASSIFIER MODAL
+   Ensure demo iframe fits contents so the modal body handles scrolling
+   ─────────────────────────────────────────────────────────── */
+#shapeClassifier-modal iframe {
+  height: auto;
+}
+
+/* let the demo size naturally rather than stretching with the text */
+#shapeClassifier-modal .modal-embed {
+  flex: 1 1 280px;
+  width: auto;
+}
+
+/* ───────────────────────────────────────────────────────────
    14.  FEATURED PROJECTS CAROUSEL
    ─────────────────────────────────────────────────────────── */
 .featured-track{

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -509,6 +509,8 @@ function openModal(id){
   modal.classList.add("active");
   document.body.classList.add("modal-open");
 
+
+
   /* focus-trap setup */
   const focusable = modal.querySelectorAll("a,button,[tabindex]:not([tabindex='-1'])");
   focusable[0]?.focus();

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -3,25 +3,69 @@
 <head>
 <meta charset="UTF-8">
 <title>Shape Classifier Demo</title>
+<link rel="stylesheet" href="css/styles.css">
 <style>
-  body   { font-family: sans-serif; text-align: center; margin: 2rem; }
-  canvas { border: 2px solid #444; touch-action: none; }
-  #buttons { margin-top: 1rem; }
-  button { margin: 0 .3rem; padding: .4rem 1rem; font-size: 1rem; }
-  #result { margin-top: 1rem; font-size: 1.2rem; }
+  html, body {
+    height: auto;
+    overflow: hidden;
+  }
+  body {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem;
+    background: var(--surface-light);
+    color: var(--text-light);
+    text-align: center;
+  }
+  #demo-box {
+    border: 4px solid var(--surface-accent);
+    padding: 1rem;
+    margin: 1rem;
+  }
+  #demo-box h2 { margin: 0 0 .3rem; }
+  #demo-box p { margin: 0 0 1rem; }
+  canvas {
+    border: 2px solid #444;
+    touch-action: none;
+    background: var(--surface-light);
+    width: 256px;
+    height: 256px;
+  }
+  #buttons {
+    margin-top: 1rem;
+    display: flex;
+    gap: .5rem;
+    justify-content: center;
+  }
+  button { margin: 0; font-size: 1rem; }
+  #result { margin-top: 1rem; font-size: 1.2rem; min-height: 1.4em; white-space: pre-line; }
+  #result.loading { animation: pulse 1s infinite; opacity: 0.6; }
+  @keyframes pulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }
+
+  @media (max-width: 600px) {
+    #buttons { flex-direction: column; }
+    #buttons button { width: 100%; }
+    #buttons button + button { margin-top: .5rem; }
+  }
 </style>
 </head>
 <body>
 
-<h2>Draw a shape!</h2>
-<canvas id="pad" width="256" height="256"></canvas>
+<div id="demo-box">
+  <h2>Draw a Shape!</h2>
+  <p>(Circle, Triangle, Square, Hexagon, Octagon)</p>
+  <p class="modal-subtitle">Model trained on Google hand-drawn circles, triangles, squares, hexagons and octagons.</p>
+  <canvas id="pad" width="256" height="256"></canvas>
 
-<div id="buttons">
-  <button id="clear">Clear</button>
-  <button id="classify">Classify</button>
+  <div id="buttons">
+    <button id="clear" class="btn-secondary">Clear</button>
+    <button id="classify" class="btn-primary">Classify</button>
+  </div>
+
+  <div id="result" class="modal-text"></div>
 </div>
-
-<div id="result"></div>
 
 <script type="module">
 const FN_URL = "https://zcosyfxhs3sntpwzo3qayki2he0kdxkw.lambda-url.us-east-2.on.aws/";   // Lambda endpoint with CORS
@@ -29,32 +73,50 @@ const FN_URL = "https://zcosyfxhs3sntpwzo3qayki2he0kdxkw.lambda-url.us-east-2.on
 // ---------- simple drawing pad ----------
 const canvas = document.getElementById("pad");
 const ctx     = canvas.getContext("2d", { willReadFrequently: true });
+const clearBtn = document.getElementById("clear");
+const classifyBtn = document.getElementById("classify");
+const resultEl = document.getElementById("result");
 
-ctx.lineWidth = 18;
+ctx.lineWidth = 6;
 ctx.lineCap   = "round";
 resetCanvas();
 
 function resetCanvas() {
-  ctx.fillStyle = "white";
+  const bg = getComputedStyle(canvas).backgroundColor;
+  ctx.fillStyle = bg;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.strokeStyle = "black";
+  ctx.strokeStyle = "white";
+  hasDrawn = false;
 }
-document.getElementById("clear").onclick = () => { resetCanvas(); draw = false; };
+clearBtn.onclick = () => { resetCanvas(); draw = false; };
 
 let draw = false;
+let hasDrawn = false;
+let firstRun = true;
 const pos = e => {
   const r = canvas.getBoundingClientRect();
-  return [ (e.touches ? e.touches[0].clientX : e.clientX) - r.left,
-           (e.touches ? e.touches[0].clientY : e.clientY) - r.top ];
+  const x = (e.touches ? e.touches[0].clientX : e.clientX) - r.left;
+  const y = (e.touches ? e.touches[0].clientY : e.clientY) - r.top;
+  const scaleX = canvas.width  / r.width;
+  const scaleY = canvas.height / r.height;
+  return [ x * scaleX, y * scaleY ];
 };
 
 canvas.addEventListener("pointerdown", e => { draw = true; ctx.beginPath(); ctx.moveTo(...pos(e)); });
-canvas.addEventListener("pointermove", e => { if (draw) { ctx.lineTo(...pos(e)); ctx.stroke(); }});
+canvas.addEventListener("pointermove", e => { if (draw) { ctx.lineTo(...pos(e)); ctx.stroke(); hasDrawn = true; }});
 ["pointerup","pointerleave","pointercancel"].forEach(evt => canvas.addEventListener(evt, () => draw = false));
 
 // ---------- classify button ----------
-document.getElementById("classify").onclick = async () => {
-  document.getElementById("result").textContent = "…predicting";
+classifyBtn.onclick = async () => {
+  if (!hasDrawn) {
+    resultEl.textContent = "Please draw a shape first.";
+    return;
+  }
+  resultEl.textContent = firstRun ? "Warming up. May take up to 10 seconds." : "Predicting...";
+  resultEl.classList.add("loading");
+  clearBtn.disabled = true;
+  classifyBtn.disabled = true;
+  firstRun = false;
   const blob = await new Promise(res => canvas.toBlob(res, "image/png"));
   const b64  = await blob.arrayBuffer().then(buf => btoa(String.fromCharCode(...new Uint8Array(buf))));
 
@@ -66,10 +128,15 @@ document.getElementById("classify").onclick = async () => {
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const {class: cls, confidence} = await res.json();
-    document.getElementById("result").textContent =
-        `Prediction: ${cls} (${(confidence*100).toFixed(1)} %)`;
+    const shape = cls.charAt(0).toUpperCase() + cls.slice(1);
+    resultEl.textContent =
+        `Prediction: ${shape}\nConfidence: ${(confidence*100).toFixed(1)}%`;
   } catch (err) {
-    document.getElementById("result").textContent = "Error: " + err;
+    resultEl.textContent = "Error: " + err;
+  } finally {
+    resultEl.classList.remove("loading");
+    clearBtn.disabled = false;
+    classifyBtn.disabled = false;
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- stretch the shape classifier embed to match modal text height
- disable scrolling inside the demo frame and style buttons with site theme
- remove JS that forced iframe height and simplify modal logic
- clarify model training caveat in the demo
- add blank canvas check, first-run message and better prediction text
- let demo size naturally and tweak canvas background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ad678ce78832395aadfda70f10d56