### PR TITLE
Fix passive event listener warnings

### DIFF
--- a/js/contributions/carousel.js
+++ b/js/contributions/carousel.js
@@ -59,12 +59,12 @@ document.addEventListener('DOMContentLoaded', () => {
     carousel.addEventListener('touchstart', e => {
       startX = e.touches[0].pageX;
       scrollLeft = carousel.scrollLeft;
-    });
+    }, { passive: true });
 
     carousel.addEventListener('touchmove', e => {
       const x = e.touches[0].pageX;
       const walk = (x - startX) * 1.5;
       carousel.scrollLeft = scrollLeft - walk;
-    });
+    }, { passive: true });
   });
 });


### PR DESCRIPTION
## Summary
- add `{ passive: true }` to touch event listeners in the contributions carousel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688af405b0488323b4389d758b9e03c8