### PR TITLE
Fix shape demo modal sizing

### DIFF
--- a/css/utilities/layout.css
+++ b/css/utilities/layout.css
@@ -78,16 +78,19 @@
 
 /* ───────────────────────────────────────────────────────────
   12c. SHAPE CLASSIFIER MODAL
-  Use a full-height iframe for the demo
+  Size the iframe to its content
   ─────────────────────────────────────────────────────────── */
 #shapeClassifier-modal iframe {
-  height: 100vh;
+  height: auto;
+  margin-top: 0;
+  width: auto;
 }
 
 #shapeClassifier-modal .modal-embed {
   flex: 0 0 auto;
   align-self: flex-start;
   width: auto;
+  overflow: visible;
 }
 
 /* ───────────────────────────────────────────────────────────

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -502,6 +502,29 @@ function openModal(id){
   const modal = document.getElementById(`${id}-modal`);
   if (!modal) return;
 
+  /* adjust the Shape Classifier iframe to fit its contents */
+  let resizeShapeDemo = null;
+  if (id === 'shapeClassifier') {
+    const iframe = modal.querySelector('iframe');
+    const measure = () => {
+      if (!iframe) return;
+      try {
+        const doc  = iframe.contentDocument || iframe.contentWindow.document;
+        const box  = doc.getElementById('demo-box') || doc.documentElement;
+        iframe.style.height = box.scrollHeight + 'px';
+        iframe.style.width  = box.scrollWidth  + 'px';
+      } catch (err) {}
+    };
+    const run = () => {
+      measure();
+      try { iframe.contentWindow.document.fonts.ready.then(measure); } catch(e) {}
+    };
+    resizeShapeDemo = measure;
+    iframe?.addEventListener('load', run, { once: true });
+    window.addEventListener('resize', measure);
+    if (iframe?.complete) run();
+  }
+
   /* put the project hash in the URL (so it’s linkable / back-able) */
   const pushed = location.hash !== `#${id}`;
   if (pushed) history.pushState({ modal:id }, "", `#${id}`);
@@ -539,6 +562,8 @@ function openModal(id){
     document.body.classList.remove("modal-open");
     document.removeEventListener("keydown", trap);
     modal.removeEventListener("click",  clickClose);
+
+    if (resizeShapeDemo) window.removeEventListener('resize', resizeShapeDemo);
 
     if (window.trackModalClose) trackModalClose(id);
 


### PR DESCRIPTION
## Summary
- tweak modal styles to let the shape demo grow to its content
- resize the shape demo iframe after fonts load so nothing is clipped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688af95ed63c8323b0465a0b92487fb7