### PR TITLE
Ensure Shape Demo fits viewport

### DIFF
--- a/css/utilities/layout.css
+++ b/css/utilities/layout.css
@@ -82,8 +82,9 @@
   ─────────────────────────────────────────────────────────── */
 #shapeClassifier-modal iframe {
   height: auto;
-  margin-top: 0;
+  margin: 0;
   width: 100%;
+  display: block;
 }
 
 #shapeClassifier-modal .modal-embed {

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -512,8 +512,28 @@ function openModal(id){
       try {
         const doc  = iframe.contentDocument || iframe.contentWindow.document;
         const box  = doc.getElementById('demo-box') || doc.documentElement;
-        iframe.style.height = box.scrollHeight + 'px';
-        iframe.style.width  = '100%';
+
+        const header  = modal.querySelector('.modal-title-strip');
+        const body    = modal.querySelector('.modal-body');
+        const content = modal.querySelector('.modal-content');
+
+        const pad    = body ?
+          parseFloat(getComputedStyle(body).paddingTop) +
+          parseFloat(getComputedStyle(body).paddingBottom) : 0;
+        const headerH = header?.getBoundingClientRect().height || 0;
+        const chrome  = headerH + pad;
+
+        const style   = getComputedStyle(content);
+        const margin  =
+          parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+        const maxModal = window.innerHeight - margin;
+        const avail    = maxModal - chrome;
+        const needed   = box.scrollHeight;
+
+        iframe.style.height    = Math.min(needed, avail) + 'px';
+        iframe.style.maxHeight = avail + 'px';
+        iframe.style.width     = '100%';
+        content.style.maxHeight = maxModal + 'px';
       } catch (err) {}
     };
     const run = () => {

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -18,10 +18,11 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     background: transparent;
     color: var(--text-light);
     text-align: center;
+    padding: 0;
     min-height: 0;
   }
   #demo-box {


### PR DESCRIPTION
## Summary
- adjust Shape Classifier iframe height using full viewport minus modal header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b6f0046b08323bb8c26892160a50a