### PR TITLE
Ensure All filter selected on See More

### DIFF
--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -209,11 +209,9 @@ function initSeeMore(){
   const filters  = document.getElementById("filters");
   const grid     = document.getElementById("projects");
   const gap      = document.getElementById("carousel-gap");
+  const menu     = document.getElementById("filter-menu");
   const mobile   = window.matchMedia("(max-width: 768px)");
   const gapPad   = gap ? parseFloat(getComputedStyle(gap).paddingTop) || 32 : 0;
-  if (gap) {
-    const color = getComputedStyle(gap).backgroundColor;
-  }
   const carousel = document.getElementById("portfolio-carousel-section");
   if(!btn || !filters || !grid) return;
   btn.addEventListener("click", () => {
@@ -273,10 +271,22 @@ function initSeeMore(){
         grid.style.paddingBottom = "";
         filters.style.paddingTop = "";
         filters.style.paddingBottom = "";
-        carousel?.scrollIntoView({ behavior: "smooth" });
+      carousel?.scrollIntoView({ behavior: "smooth" });
       }, 450); // height transition duration
     } else {
       // expand grid, filters, and gap smoothly
+      if (menu) {
+        const allBtn = menu.querySelector('[data-filter="all"]');
+        if (allBtn) {
+          [...menu.children].forEach(b => {
+            b.classList.replace("btn-primary", "btn-secondary");
+            b.setAttribute("aria-selected", "false");
+          });
+          allBtn.classList.replace("btn-secondary", "btn-primary");
+          allBtn.setAttribute("aria-selected", "true");
+        }
+        [...grid.children].forEach(c => c.classList.remove("hide"));
+      }
       filters.classList.remove("hide");
       grid.classList.remove("hide");
       if (gap) gap.classList.remove("hide");
@@ -284,6 +294,11 @@ function initSeeMore(){
       filters.classList.add("active");
       grid.classList.add("active");
       if (gap) gap.classList.add("active");
+
+      /* Safari sometimes returns 0 if measured immediately */
+      void grid.offsetHeight;
+      void filters.offsetHeight;
+
       const gTarget = grid.scrollHeight;
       const fTarget = filters.scrollHeight;
       const gapTarget = gap ? gapPad : 0;


### PR DESCRIPTION
## Summary
- grab `filter-menu` element when initializing portfolio See More button
- reset filter buttons and show all cards when expanding the projects grid
- force a reflow before measuring height so Safari correctly expands the grid
- clean up unused variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ba322395083238e3b436d101e625c