### PR TITLE
Align classify button width with canvas

### DIFF
--- a/shape-demo.html
+++ b/shape-demo.html
@@ -70,7 +70,12 @@
     justify-content: center;
   }
   button { margin: 0; font-size: 1rem; }
+  #classify {
+    width: min(60vmin, 256px);
+    margin: 0 auto;
+  }
   #result {
+    line-height: 1.2;
     margin: 1rem auto 0;
     font-size: 1rem;
     height: 3.6em;
@@ -88,7 +93,7 @@
 
   @media (max-width: 600px) {
     #buttons { flex-direction: column; }
-    #buttons button { width: 100%; }
+    #buttons button { width: min(60vmin, 256px); margin: 0 auto; }
     #buttons button + button { margin-top: .5rem; }
   }
 </style>
@@ -128,6 +133,16 @@ const clearBtn    = document.getElementById("clear");
 const classifyBtn = document.getElementById("classify");
 const resultEl    = document.getElementById("result");
 
+function fitResultText() {
+  resultEl.style.fontSize = "";
+  const maxH = resultEl.clientHeight;
+  let size = parseFloat(getComputedStyle(resultEl).fontSize);
+  while (resultEl.scrollHeight > maxH && size > 8) {
+    size -= 1;
+    resultEl.style.fontSize = size + "px";
+  }
+}
+
 const CANVAS_BG = "#000";
 let   hasDrawn   = false;
 
@@ -162,10 +177,12 @@ canvas.addEventListener("pointermove", e => { if (draw) { e.preventDefault(); ct
 classifyBtn.onclick = async () => {
   if (!hasDrawn) {
     resultEl.textContent = "Please draw a shape first.";
+    fitResultText();
     notifyResize();
     return;
   }
   resultEl.textContent = firstRun ? "Warming up. May take up to 10 seconds." : "Predicting...";
+  fitResultText();
   notifyResize();
   resultEl.classList.add("loading");
   clearBtn.disabled = true;
@@ -185,8 +202,10 @@ classifyBtn.onclick = async () => {
     const shape = cls.charAt(0).toUpperCase() + cls.slice(1);
     resultEl.textContent =
         `Prediction: ${shape}\nConfidence: ${(confidence*100).toFixed(1)}%`;
+    fitResultText();
   } catch (err) {
     resultEl.textContent = "Error: " + err;
+    fitResultText();
   } finally {
     resultEl.classList.remove("loading");
     clearBtn.disabled = false;


### PR DESCRIPTION
## Summary
- keep consistent width across demo elements
- adjust small-screen rule for classify button
- center classify button
- resize output text dynamically to avoid overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cb85818c88323b3765c7aa81e009d