### PR TITLE
Improve shape demo trash button visibility

### DIFF
--- a/shape-demo.html
+++ b/shape-demo.html
@@ -51,16 +51,16 @@
     width: 32px;
     height: 32px;
     border: none;
-    background: rgba(0,0,0,0.5);
+    background: var(--primary);
     border-radius: 4px;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
   }
-  #clear i { color: var(--text-light); }
+  #clear i { color: var(--bg); }
   #clear:hover {
-    background: var(--primary);
+    filter: brightness(1.1);
   }
   #clear:hover i { color: var(--bg); }
   #buttons {


### PR DESCRIPTION
## Summary
- keep the Shape Classifier trash icon highlighted by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cbe64dfe88323a8350071b6fe29d7