### PR TITLE
Add chatbot demo with status updates

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Chatbot Demo</title>
+<link rel="stylesheet" href="css/styles.css">
+<link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" rel="stylesheet"></noscript>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: auto;
+    overflow: hidden;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    color: var(--text-light);
+    text-align: center;
+    min-height: 0;
+  }
+  #demo-box {
+    padding: 1rem;
+    margin: 0;
+    text-align: left;
+    width: min(80vmin, 400px);
+  }
+  #prompt {
+    width: 100%;
+    height: 6em;
+    font-size: 0.9rem;
+  }
+  #buttons {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: flex-start;
+  }
+  #status {
+    margin-top: 1rem;
+    min-height: 1.2em;
+    font-size: 0.9rem;
+    text-align: left;
+  }
+  #answer {
+    line-height: 1.4;
+    margin: 1rem 0 0;
+    font-size: 0.9rem;
+    width: 100%;
+    border: 1px solid var(--surface-accent);
+    padding: 0.5rem;
+    box-sizing: border-box;
+    min-height: 6em;
+    text-align: left;
+    overflow-wrap: anywhere;
+  }
+  #answer.loading { animation: pulse 1s infinite; opacity: 0.6; }
+  #answer .user { font-weight: 500; }
+  #answer .bot { margin-top: 0.5rem; }
+  #answer .sources { margin-top: 0.5rem; font-size: 0.8rem; color: var(--text-muted); }
+  #answer .sources ul { padding-left: 1.2rem; margin: 0; }
+  #answer .sources a { color: var(--primary); word-break: break-all; }
+  @keyframes pulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }
+</style>
+</head>
+<body>
+<script>
+  function notifyResize() {
+    try { parent.postMessage({ type: 'chatbot-demo-resize' }, '*'); } catch(e) {}
+  }
+  window.addEventListener('load', notifyResize);
+  try { document.fonts.ready.then(notifyResize); } catch(e) {}
+</script>
+<div id="demo-box">
+  <h2>Ask the Chatbot</h2>
+  <textarea id="prompt" placeholder="Enter your question..."></textarea>
+  <div id="buttons">
+    <button id="ask" class="btn-primary">Ask</button>
+  </div>
+  <div id="status" class="modal-subtitle"></div>
+  <div id="answer" class="modal-text"></div>
+</div>
+<script>
+const API_URL = 'https://ovodkr9oad.execute-api.us-east-2.amazonaws.com/prod';
+async function ask(prompt, onStatus = () => {}) {
+  onStatus('SUBMITTING');
+  const submit = await fetch(`${API_URL}/submit`, {
+    method: 'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({prompt})
+  }).then(r=>r.json());
+  const outputUri = submit.outputUri;
+  async function poll() {
+    const url = `${API_URL}/result?outputUri=${encodeURIComponent(outputUri)}`;
+    const res = await fetch(url).then(r=>r.json());
+    onStatus(res.status);
+    if (res.status === 'READY') return res.data;
+    if (res.status === 'FAILED') throw new Error(res.error || 'failed');
+    await new Promise(r=>setTimeout(r, 2000));
+    return poll();
+  }
+  return poll();
+}
+const promptEl = document.getElementById('prompt');
+const statusEl = document.getElementById('status');
+const answerEl = document.getElementById('answer');
+const askBtn = document.getElementById('ask');
+askBtn.onclick = async () => {
+  const prompt = promptEl.value.trim();
+  if (!prompt) return;
+  answerEl.innerHTML = '';
+  answerEl.classList.add('loading');
+  const updateStatus = txt => { statusEl.textContent = txt; notifyResize(); };
+  updateStatus('Submitting...');
+  askBtn.disabled = true;
+  try {
+    const data = await ask(prompt, status => {
+      if (status === 'PENDING') updateStatus('Processing with SageMaker...');
+    });
+    updateStatus('Complete');
+    answerEl.classList.remove('loading');
+    const userDiv = document.createElement('div');
+    userDiv.className = 'user';
+    userDiv.textContent = `You: ${prompt}`;
+    const botDiv = document.createElement('div');
+    botDiv.className = 'bot';
+    botDiv.textContent = `Bot: ${data.generated_text || JSON.stringify(data)}`;
+    answerEl.append(userDiv, botDiv);
+    const urls = data.source_urls || data.sources || data.urls;
+    if (Array.isArray(urls) && urls.length) {
+      const srcDiv = document.createElement('div');
+      srcDiv.className = 'sources';
+      const srcLabel = document.createElement('div');
+      srcLabel.textContent = 'Sources:';
+      const list = document.createElement('ul');
+      urls.forEach(u => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = u;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = u;
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+      srcDiv.append(srcLabel, list);
+      answerEl.appendChild(srcDiv);
+    }
+  } catch(err) {
+    answerEl.classList.remove('loading');
+    updateStatus('Error');
+    answerEl.textContent = err.message;
+  } finally {
+    askBtn.disabled = false;
+    notifyResize();
+  }
+};
+</script>
+</body>
+</html>

--- a/css/utilities/layout.css
+++ b/css/utilities/layout.css
@@ -80,14 +80,16 @@
   12c. SHAPE CLASSIFIER MODAL
   Size the iframe to its content
   ─────────────────────────────────────────────────────────── */
-#shapeClassifier-modal iframe {
+#shapeClassifier-modal iframe,
+#chatbotLora-modal iframe {
   height: auto;
   margin-top: 0;
   width: 100%;
   border: 1px solid var(--surface-accent);
 }
 
-#shapeClassifier-modal .modal-embed {
+#shapeClassifier-modal .modal-embed,
+#chatbotLora-modal .modal-embed {
   flex: 0 0 50%;
   max-width: 50%;
   align-self: flex-start;
@@ -95,7 +97,8 @@
 }
 
 @media (max-width: 768px) {
-  #shapeClassifier-modal .modal-embed {
+  #shapeClassifier-modal .modal-embed,
+  #chatbotLora-modal .modal-embed {
     flex-basis: 100%;
     max-width: 100%;
   }

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -519,10 +519,10 @@ function openModal(id){
   const modal = document.getElementById(`${id}-modal`);
   if (!modal) return;
 
-  /* adjust the Shape Classifier iframe to fit its contents */
+  /* adjust embedded demo if needed to fit its contents */
   let resizeShapeDemo = null;
   let resizeMsg = null;
-  if (id === 'shapeClassifier') {
+  if (id === 'shapeClassifier' || id === 'chatbotLora') {
     const iframe = modal.querySelector('iframe');
     const measure = () => {
       if (!iframe) return;
@@ -540,8 +540,9 @@ function openModal(id){
     resizeShapeDemo = measure;
     iframe?.addEventListener('load', run, { once: true });
     window.addEventListener('resize', measure);
+    const resizeType = id === 'shapeClassifier' ? 'shape-demo-resize' : 'chatbot-demo-resize';
     resizeMsg = e => {
-      if (e.source === iframe.contentWindow && e.data?.type === 'shape-demo-resize') measure();
+      if (e.source === iframe.contentWindow && e.data?.type === resizeType) measure();
     };
     window.addEventListener('message', resizeMsg);
     if (iframe?.contentDocument?.readyState === 'complete') {

--- a/js/portfolio/projects-data.js
+++ b/js/portfolio/projects-data.js
@@ -346,13 +346,17 @@ window.PROJECTS = [
     resources: [
       { icon: "img/icons/github-icon.png", url: "https://github.com/danielshort3/Chatbot-LoRA-RAG", label: "GitHub" }
     ],
+    embed : {
+      type : "iframe",
+      url  : "chatbot-demo.html"
+    },
     problem : "Generic chatbots lacked Visit Grand Junction's tone and rarely suggested our content.",
     actions : [
-      "Scraped Visit Grand Junction pages to capture the brand voice.",
-      "Built a FAISS index and used LoRA to fine-tune an open-source LLM in Docker."
+      "Scraped Visit Grand Junction pages to capture the brand voice and built a retrieval index.",
+      "Linked two AWS Lambda functions that queue prompts and fetch SageMaker-generated replies with source links."
     ],
     results : [
-      "Responsive chatbot stays current with our content and engages potential guests."
+      "Serverless RAG chatbot scales on demand and returns grounded answers with references."
     ]
   },
 


### PR DESCRIPTION
## Summary
- add chatbot-demo.html with poll-based API call and status updates
- embed chatbot demo in portfolio project list and auto-resize modal
- style chatbot modal alongside shape classifier
- refine chatbot output formatting and update project description

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a52bb09c832398fd31cea0eb6f95