### PR TITLE
feat: add task checklist and refine chat UI

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -36,17 +36,52 @@
     width: 100%;
     height: 6em;
     font-size: 0.9rem;
+    background: var(--surface-light);
+    color: var(--text-light);
+    border: 1px solid var(--surface-accent);
+    border-radius: 8px;
+    padding: 0.5rem;
+    resize: vertical;
+  }
+  #prompt::placeholder {
+    color: var(--text-muted);
+  }
+  #prompt:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
   }
   #buttons {
     margin-top: 1rem;
     display: flex;
-    justify-content: flex-start;
+    justify-content: flex-end;
   }
   #status {
     margin-top: 1rem;
     min-height: 1.2em;
     font-size: 0.9rem;
     text-align: left;
+  }
+  #status ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+  #status li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.25rem;
+  }
+  #status li i {
+    margin-right: 0.5rem;
+  }
+  #status li.not-started {
+    color: var(--text-muted);
+  }
+  #status li.in-progress {
+    color: var(--secondary);
+  }
+  #status li.done {
+    color: var(--primary);
   }
   #answer {
     line-height: 1.4;
@@ -57,15 +92,48 @@
     padding: 0.5rem;
     box-sizing: border-box;
     min-height: 6em;
+    max-height: 40vh;
     text-align: left;
+    overflow-y: auto;
     overflow-wrap: anywhere;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: var(--surface);
+    border-radius: 8px;
   }
   #answer.loading { animation: pulse 1s infinite; opacity: 0.6; }
-  #answer .user { font-weight: 500; }
-  #answer .bot { margin-top: 0.5rem; }
-  #answer .sources { margin-top: 0.5rem; font-size: 0.8rem; color: var(--text-muted); }
-  #answer .sources ul { padding-left: 1.2rem; margin: 0; }
-  #answer .sources a { color: var(--primary); word-break: break-all; }
+  .message {
+    padding: 0.5rem;
+    border: 1px solid var(--surface-accent);
+    border-radius: 8px;
+    background: var(--surface-light);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .message .label {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+  .message.user .label {
+    color: var(--primary);
+  }
+  .message.bot .label {
+    color: var(--secondary);
+  }
+  #answer .sources {
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+  #answer .sources ul {
+    padding-left: 1.2rem;
+    margin: 0;
+  }
+  #answer .sources a {
+    color: var(--primary);
+    word-break: break-all;
+  }
   @keyframes pulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }
 </style>
 </head>
@@ -79,10 +147,13 @@
 </script>
 <div id="demo-box">
   <h2>Ask the Chatbot</h2>
-  <textarea id="prompt" placeholder="Enter your question..."></textarea>
-  <div id="buttons">
-    <button id="ask" class="btn-primary">Ask</button>
-  </div>
+  <form id="chat-form">
+    <label for="prompt" class="modal-subtitle">Your message</label>
+    <textarea id="prompt" placeholder="Type your message..."></textarea>
+    <div id="buttons">
+      <button id="ask" type="submit" class="btn-primary">Ask</button>
+    </div>
+  </form>
   <div id="status" class="modal-subtitle"></div>
   <div id="answer" class="modal-text"></div>
 </div>
@@ -110,27 +181,81 @@ const promptEl = document.getElementById('prompt');
 const statusEl = document.getElementById('status');
 const answerEl = document.getElementById('answer');
 const askBtn = document.getElementById('ask');
-askBtn.onclick = async () => {
+const form = document.getElementById('chat-form');
+const tasks = [
+  { id: 'submit', label: 'Submit question' },
+  { id: 'process', label: 'Processing with SageMaker' },
+  { id: 'complete', label: 'Complete' }
+];
+
+function appendMessage(role, text) {
+  const msg = document.createElement('div');
+  msg.className = `message ${role}`;
+  const label = document.createElement('div');
+  label.className = 'label';
+  label.textContent = role === 'user' ? 'You' : 'Assistant';
+  const content = document.createElement('div');
+  content.className = 'content';
+  content.textContent = text;
+  msg.append(label, content);
+  answerEl.appendChild(msg);
+  answerEl.scrollTop = answerEl.scrollHeight;
+  notifyResize();
+}
+
+function renderTaskList() {
+  statusEl.innerHTML = '';
+  const ul = document.createElement('ul');
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.id = `task-${t.id}`;
+    li.className = 'not-started';
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-xmark';
+    li.appendChild(icon);
+    li.append(` ${t.label}`);
+    ul.appendChild(li);
+  });
+  statusEl.appendChild(ul);
+  notifyResize();
+}
+
+function setTaskState(id, state) {
+  const li = document.getElementById(`task-${id}`);
+  if (!li) return;
+  const icon = li.querySelector('i');
+  li.className = state;
+  if (state === 'in-progress') {
+    icon.className = 'fa-solid fa-spinner fa-spin';
+  } else if (state === 'done') {
+    icon.className = 'fa-solid fa-check';
+  } else {
+    icon.className = 'fa-solid fa-xmark';
+  }
+  notifyResize();
+}
+
+async function handleSubmit(e) {
+  if (e) e.preventDefault();
   const prompt = promptEl.value.trim();
   if (!prompt) return;
-  answerEl.innerHTML = '';
+  appendMessage('user', prompt);
   answerEl.classList.add('loading');
-  const updateStatus = txt => { statusEl.textContent = txt; notifyResize(); };
-  updateStatus('Submitting...');
+  renderTaskList();
+  setTaskState('submit', 'in-progress');
   askBtn.disabled = true;
   try {
     const data = await ask(prompt, status => {
-      if (status === 'PENDING') updateStatus('Processing with SageMaker...');
+      if (status === 'PENDING') {
+        setTaskState('submit', 'done');
+        setTaskState('process', 'in-progress');
+      } else if (status === 'READY') {
+        setTaskState('process', 'done');
+        setTaskState('complete', 'done');
+      }
     });
-    updateStatus('Complete');
     answerEl.classList.remove('loading');
-    const userDiv = document.createElement('div');
-    userDiv.className = 'user';
-    userDiv.textContent = `You: ${prompt}`;
-    const botDiv = document.createElement('div');
-    botDiv.className = 'bot';
-    botDiv.textContent = `Bot: ${data.generated_text || JSON.stringify(data)}`;
-    answerEl.append(userDiv, botDiv);
+    appendMessage('bot', data.generated_text || JSON.stringify(data));
     const urls = data.source_urls || data.sources || data.urls;
     if (Array.isArray(urls) && urls.length) {
       const srcDiv = document.createElement('div');
@@ -149,17 +274,21 @@ askBtn.onclick = async () => {
         list.appendChild(li);
       });
       srcDiv.append(srcLabel, list);
-      answerEl.appendChild(srcDiv);
+      answerEl.lastElementChild.appendChild(srcDiv);
     }
   } catch(err) {
     answerEl.classList.remove('loading');
-    updateStatus('Error');
-    answerEl.textContent = err.message;
+    setTaskState('process', 'not-started');
+    setTaskState('complete', 'not-started');
+    appendMessage('bot', err.message);
   } finally {
     askBtn.disabled = false;
     notifyResize();
   }
-};
+}
+
+askBtn.onclick = handleSubmit;
+form.addEventListener('submit', handleSubmit);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add color-coded checklist to chatbot demo
- style transcript with labeled user and assistant blocks
- theme chat input and submit button to match site design

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689619e5b1f48323bbcac0dff5fe9270