### PR TITLE
Improve demos with step feedback and chatbot UI upgrades

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -52,8 +52,10 @@
   }
   #buttons {
     margin-top: 1rem;
-    display: flex;
-    justify-content: flex-end;
+    width: 100%;
+  }
+  #ask {
+    width: 100%;
   }
   #status {
     margin-top: 1rem;
@@ -83,11 +85,22 @@
   #status li.done {
     color: var(--primary);
   }
+  #status li.flashing {
+    animation: pulse 1s infinite;
+  }
+  #demo-box h2 {
+    text-align: center;
+  }
   #answer {
     line-height: 1.4;
     margin: 1rem 0 0;
     font-size: 0.9rem;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .exchange {
     border: 1px solid var(--surface-accent);
     padding: 0.5rem;
     box-sizing: border-box;
@@ -102,7 +115,6 @@
     background: var(--surface);
     border-radius: 8px;
   }
-  #answer.loading { animation: pulse 1s infinite; opacity: 0.6; }
   .message {
     padding: 0.5rem;
     border: 1px solid var(--surface-accent);
@@ -146,7 +158,8 @@
   try { document.fonts.ready.then(notifyResize); } catch(e) {}
 </script>
 <div id="demo-box">
-  <h2>Ask the Chatbot</h2>
+  <h2>Ask the Demo Chatbot</h2>
+  <p class="modal-subtitle">Input and output data is saved on AWS servers.</p>
   <form id="chat-form">
     <label for="prompt" class="modal-subtitle">Your message</label>
     <textarea id="prompt" placeholder="Type your message..."></textarea>
@@ -188,7 +201,15 @@ const tasks = [
   { id: 'complete', label: 'Complete' }
 ];
 
-function appendMessage(role, text) {
+function createExchange() {
+  const ex = document.createElement('div');
+  ex.className = 'exchange';
+  answerEl.appendChild(ex);
+  answerEl.scrollTop = answerEl.scrollHeight;
+  return ex;
+}
+
+function appendMessage(container, role, text) {
   const msg = document.createElement('div');
   msg.className = `message ${role}`;
   const label = document.createElement('div');
@@ -198,8 +219,8 @@ function appendMessage(role, text) {
   content.className = 'content';
   content.textContent = text;
   msg.append(label, content);
-  answerEl.appendChild(msg);
-  answerEl.scrollTop = answerEl.scrollHeight;
+  container.appendChild(msg);
+  container.scrollTop = container.scrollHeight;
   notifyResize();
 }
 
@@ -225,6 +246,7 @@ function setTaskState(id, state) {
   if (!li) return;
   const icon = li.querySelector('i');
   li.className = state;
+  li.classList.toggle('flashing', id === 'process' && state === 'in-progress');
   if (state === 'in-progress') {
     icon.className = 'fa-solid fa-spinner fa-spin';
   } else if (state === 'done') {
@@ -239,8 +261,9 @@ async function handleSubmit(e) {
   if (e) e.preventDefault();
   const prompt = promptEl.value.trim();
   if (!prompt) return;
-  appendMessage('user', prompt);
-  answerEl.classList.add('loading');
+  const exchange = createExchange();
+  appendMessage(exchange, 'user', prompt);
+  promptEl.value = '';
   renderTaskList();
   setTaskState('submit', 'in-progress');
   askBtn.disabled = true;
@@ -254,8 +277,7 @@ async function handleSubmit(e) {
         setTaskState('complete', 'done');
       }
     });
-    answerEl.classList.remove('loading');
-    appendMessage('bot', data.generated_text || JSON.stringify(data));
+    appendMessage(exchange, 'bot', data.generated_text || JSON.stringify(data));
     const urls = data.source_urls || data.sources || data.urls;
     if (Array.isArray(urls) && urls.length) {
       const srcDiv = document.createElement('div');
@@ -274,13 +296,13 @@ async function handleSubmit(e) {
         list.appendChild(li);
       });
       srcDiv.append(srcLabel, list);
-      answerEl.lastElementChild.appendChild(srcDiv);
+      exchange.lastElementChild.appendChild(srcDiv);
+      exchange.scrollTop = exchange.scrollHeight;
     }
   } catch(err) {
-    answerEl.classList.remove('loading');
     setTaskState('process', 'not-started');
     setTaskState('complete', 'not-started');
-    appendMessage('bot', err.message);
+    appendMessage(exchange, 'bot', err.message);
   } finally {
     askBtn.disabled = false;
     notifyResize();

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -88,7 +88,40 @@
     align-items: center;
     justify-content: center;
   }
-  #result.loading { animation: pulse 1s infinite; opacity: 0.6; }
+  #status {
+    margin-top: 1rem;
+    min-height: 1.2em;
+    font-size: 1rem;
+    text-align: left;
+    width: min(60vmin, 256px);
+    margin-left: auto;
+    margin-right: auto;
+  }
+  #status ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+  #status li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.25rem;
+  }
+  #status li i {
+    margin-right: 0.5rem;
+  }
+  #status li.not-started {
+    color: var(--text-muted);
+  }
+  #status li.in-progress {
+    color: var(--secondary);
+  }
+  #status li.done {
+    color: var(--primary);
+  }
+  #status li.flashing {
+    animation: pulse 1s infinite;
+  }
   @keyframes pulse { 0%,100% { opacity: 0.6; } 50% { opacity: 1; } }
 
   @media (max-width: 600px) {
@@ -120,6 +153,7 @@
     <button id="classify" class="btn-primary">Classify</button>
   </div>
 
+  <div id="status" class="modal-subtitle"></div>
   <div id="result" class="modal-text"></div>
 </div>
 
@@ -132,6 +166,46 @@ const ctx         = canvas.getContext("2d", { willReadFrequently: true });
 const clearBtn    = document.getElementById("clear");
 const classifyBtn = document.getElementById("classify");
 const resultEl    = document.getElementById("result");
+const statusEl    = document.getElementById("status");
+
+const tasks = [
+  { id: 'submit', label: 'Submit drawing' },
+  { id: 'process', label: 'Processing with SageMaker' },
+  { id: 'complete', label: 'Complete' }
+];
+
+function renderTaskList() {
+  statusEl.innerHTML = '';
+  const ul = document.createElement('ul');
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.id = `task-${t.id}`;
+    li.className = 'not-started';
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-xmark';
+    li.appendChild(icon);
+    li.append(` ${t.label}`);
+    ul.appendChild(li);
+  });
+  statusEl.appendChild(ul);
+  notifyResize();
+}
+
+function setTaskState(id, state) {
+  const li = document.getElementById(`task-${id}`);
+  if (!li) return;
+  const icon = li.querySelector('i');
+  li.className = state;
+  li.classList.toggle('flashing', id === 'process' && state === 'in-progress');
+  if (state === 'in-progress') {
+    icon.className = 'fa-solid fa-spinner fa-spin';
+  } else if (state === 'done') {
+    icon.className = 'fa-solid fa-check';
+  } else {
+    icon.className = 'fa-solid fa-xmark';
+  }
+  notifyResize();
+}
 
 function fitResultText() {
   resultEl.style.fontSize = "";
@@ -159,7 +233,6 @@ function resetCanvas() {
 clearBtn.onclick = () => { resetCanvas(); draw = false; };
 
 let draw = false;
-let firstRun = true;
 const pos = e => {
   const r = canvas.getBoundingClientRect();
   const x = (e.touches ? e.touches[0].clientX : e.clientX) - r.left;
@@ -181,17 +254,17 @@ classifyBtn.onclick = async () => {
     notifyResize();
     return;
   }
-  resultEl.textContent = firstRun ? "Warming up. May take up to 10 seconds." : "Predicting...";
-  fitResultText();
-  notifyResize();
-  resultEl.classList.add("loading");
+  resultEl.textContent = '';
+  renderTaskList();
+  setTaskState('submit', 'in-progress');
   clearBtn.disabled = true;
   classifyBtn.disabled = true;
-  firstRun = false;
   const blob = await new Promise(res => canvas.toBlob(res, "image/png"));
   const b64  = await blob.arrayBuffer().then(buf => btoa(String.fromCharCode(...new Uint8Array(buf))));
 
   try {
+    setTaskState('submit', 'done');
+    setTaskState('process', 'in-progress');
     const res   = await fetch(FN_URL, {
       method : "POST",
       headers: { "Content-Type": "application/json" },
@@ -200,14 +273,17 @@ classifyBtn.onclick = async () => {
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const {class: cls, confidence} = await res.json();
     const shape = cls.charAt(0).toUpperCase() + cls.slice(1);
+    setTaskState('process', 'done');
+    setTaskState('complete', 'done');
     resultEl.textContent =
         `Prediction: ${shape}\nConfidence: ${(confidence*100).toFixed(1)}%`;
     fitResultText();
   } catch (err) {
+    setTaskState('process', 'not-started');
+    setTaskState('complete', 'not-started');
     resultEl.textContent = "Error: " + err;
     fitResultText();
   } finally {
-    resultEl.classList.remove("loading");
     clearBtn.disabled = false;
     classifyBtn.disabled = false;
     notifyResize();


### PR DESCRIPTION
## Summary
- Add step-by-step processing checklist to the shape analyzer demo with flashing indicator for active processing
- Revamp chatbot demo with data disclaimer, centered title, full-width Ask button, and separate scrollable message boxes
- Restrict flashing animation to processing step for chatbot demo and show outputs only after completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965cbaa01883238882db0ac0dac9b1