### PR TITLE
Enhance chatbot prompts with animation and ordering

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -94,38 +94,44 @@
   #demo-box h2 {
     text-align: center;
   }
+  #history {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
+    scrollbar-gutter: stable;
+  }
+  #history button {
+    flex: 0 0 auto;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--surface-accent);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text-light);
+    cursor: pointer;
+  }
+  #history button.active {
+    background: var(--primary);
+    color: var(--bg);
+  }
   #answer {
     line-height: 1.4;
-    margin: 1rem 0 0;
+    margin: 1rem 0;
     font-size: 0.9rem;
     width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  .exchange-wrapper { display:flex; flex-direction:column; gap:0.5rem; }
-  .exchange-toggle {
-    width:100%; text-align:left; background:var(--surface); color:var(--text-light);
-    border:1px solid var(--surface-accent); border-radius:8px; padding:0.5rem; cursor:pointer;
-  }
-  .exchange-wrapper.collapsed .exchange { display:none; }
-  .exchange-toggle::before { content:'\25BE '; }
-  .exchange-wrapper.collapsed .exchange-toggle::before { content:'\25B8 '; }
-  .exchange {
-    border: 1px solid var(--surface-accent);
-    padding: 0.5rem;
-    box-sizing: border-box;
-    min-height: 6em;
-    max-height: 40vh;
-    text-align: left;
+    height: 40vh;
     overflow-y: auto;
-    scrollbar-gutter: stable;
-    overflow-wrap: anywhere;
+    box-sizing: border-box;
+    border: 1px solid var(--surface-accent);
+    border-radius: 8px;
+    padding: 0.5rem;
+    background: var(--surface);
+  }
+  .exchange {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    background: var(--surface);
-    border-radius: 8px;
   }
   .message {
     padding: 0.5rem;
@@ -172,15 +178,15 @@
 <div id="demo-box">
   <h2>Ask the Demo Chatbot</h2>
   <p class="modal-subtitle">Input and output data is saved on AWS servers.</p>
+  <div id="history"></div>
+  <div id="answer" class="modal-text"></div>
   <form id="chat-form">
-    <label for="prompt" class="modal-subtitle">Your message</label>
     <textarea id="prompt" placeholder="Type your message..."></textarea>
       <div id="buttons">
         <button id="ask" type="submit" class="btn-primary">Submit</button>
       </div>
   </form>
   <div id="status" class="modal-subtitle"></div>
-  <div id="answer" class="modal-text"></div>
 </div>
 <script>
 const API_URL = 'https://ovodkr9oad.execute-api.us-east-2.amazonaws.com/prod';
@@ -207,34 +213,36 @@ const statusEl = document.getElementById('status');
 const answerEl = document.getElementById('answer');
 const askBtn = document.getElementById('ask');
 const form = document.getElementById('chat-form');
+const historyEl = document.getElementById('history');
+const exchanges = [];
 const tasks = [
   { id: 'submit', label: 'Submit prompt' },
   { id: 'process', label: 'Processing with AWS SageMaker' },
   { id: 'complete', label: 'Complete' }
 ];
 
-let exchangeCount = 0;
+function showExchange(index) {
+  answerEl.innerHTML = '';
+  answerEl.appendChild(exchanges[index].element);
+  [...historyEl.children].forEach((btn, i) => {
+    btn.classList.toggle('active', i === index);
+  });
+  notifyResize();
+}
 
 function createExchange(prompt) {
-  document.querySelectorAll('.exchange-wrapper').forEach(w => w.classList.add('collapsed'));
-  exchangeCount++;
-  const wrapper = document.createElement('div');
-  wrapper.className = 'exchange-wrapper';
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'exchange-toggle';
-  const summary = prompt.length > 40 ? prompt.slice(0,37) + '...' : prompt;
-  btn.textContent = `${exchangeCount}. ${summary}`;
   const ex = document.createElement('div');
   ex.className = 'exchange';
-  btn.onclick = () => {
-    wrapper.classList.toggle('collapsed');
-    notifyResize();
-  };
-  wrapper.append(btn, ex);
-  answerEl.prepend(wrapper);
-  answerEl.scrollTop = 0;
-  notifyResize();
+  const index = exchanges.length;
+  exchanges.push({ prompt, element: ex });
+  const summary = prompt.length > 40 ? prompt.slice(0,37) + '...' : prompt;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = `${index + 1}. ${summary}`;
+  btn.onclick = () => showExchange(index);
+  historyEl.appendChild(btn);
+  historyEl.scrollLeft = historyEl.scrollWidth;
+  showExchange(index);
   return ex;
 }
 


### PR DESCRIPTION
## Summary
- Simplify chatbot task steps to plain text styling matching shape analyzer
- Display prior question history in a horizontal scroll bar and show selected exchange in a fixed-height, scrollable box above the input
- Remove redundant "Your message" label for a cleaner chat form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966f6b17f48323b551488d9c0a0834