### PR TITLE
fix: remove iframe scroll wiggle

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -60,6 +60,9 @@
             border-radius: var(--radius);
             box-shadow: var(--shadow-2);
             overflow: hidden; /* avoid clip issues on some mobile browsers */
+            display: flex;
+            flex-direction: column;
+            max-height: 100%;
         }
 
         header.card-header {
@@ -129,6 +132,7 @@
         #status {
             padding: 10px 16px 0;
             min-height: 34px;
+            flex-shrink: 0;
         }
         /* reserve space to avoid layout shift */
 
@@ -244,10 +248,11 @@
             flex-direction: column;
             gap: 12px;
             padding: 12px 16px 0;
-            max-height: min(66vh, 720px);
             overflow: auto;
             scroll-behavior: smooth;
             min-width: 0; /* allow inner content to shrink */
+            flex: 1 1 auto;
+            min-height: 0;
         }
 
         .exchange-wrapper {
@@ -386,6 +391,7 @@
             border-top: 1px solid var(--surface-accent);
             display: grid;
             gap: 10px;
+            flex-shrink: 0;
         }
 
         /* Chip style for quick prompts */

--- a/css/base/base.css
+++ b/css/base/base.css
@@ -7,11 +7,11 @@ html,body{
   scrollbar-width:none;
   font-family:'Inter',sans-serif;
   background:var(--bg);color:var(--text-light);
-  line-height:1.6;-webkit-font-smoothing:antialiased;
+  -webkit-font-smoothing:antialiased;
 }
 html::-webkit-scrollbar,body::-webkit-scrollbar{display:none}
 
-body{display:flex;flex-direction:column;min-height:100vh;overflow-x:hidden}
+body{display:flex;flex-direction:column;min-height:100vh;overflow-x:hidden;line-height:1.5}
 main{flex:1 0 auto}
 .wrapper{margin-inline:24px}
 a{color:inherit;text-decoration:none}


### PR DESCRIPTION
## Summary
- avoid iframe scrolling caused by base line-height by moving it off the root and adjusting body line-height
- constrain Chatbot demo card to the viewport and let the message list flex so no extra scroll remains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e66a72048323b4793a184ed8d027