### PR TITLE
Allow demo iframes to fit content

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -636,6 +636,18 @@
     <script>
         /* notify parent for iframed embeds — only once to keep height static */
         function notifyResize() { try { parent.postMessage({ type: 'chatbot-demo-resize' }, '*'); } catch (e) { } }
+
+        /* When embedded in a modal iframe, allow the card to size to its content */
+        const isFramed = window.self !== window.top;
+        if (isFramed) {
+            document.addEventListener('DOMContentLoaded', () => {
+                document.documentElement.style.height = 'auto';
+                document.body.style.height = 'auto';
+                const box = document.getElementById('demo-box');
+                if (box) box.style.height = 'auto';
+            });
+        }
+
         window.addEventListener('load', notifyResize);
         try { document.fonts?.ready?.then(notifyResize); } catch (e) { }
     </script>

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -462,6 +462,18 @@
     <script>
         /* notify parent for iframed embeds — only once to keep height static */
         function notifyResize() { try { parent.postMessage({ type: 'shape-demo-resize' }, '*'); } catch (e) { } }
+
+        /* When embedded in a modal iframe, let the card expand naturally */
+        const isFramed = window.self !== window.top;
+        if (isFramed) {
+            document.addEventListener('DOMContentLoaded', () => {
+                document.documentElement.style.height = 'auto';
+                document.body.style.height = 'auto';
+                const box = document.getElementById('demo-box');
+                if (box) box.style.height = 'auto';
+            });
+        }
+
         window.addEventListener('load', notifyResize);
         try { document.fonts?.ready?.then(notifyResize); } catch (e) { }
     </script>


### PR DESCRIPTION
## Summary
- Ensure chatbot and shape analyzer demos expand naturally when embedded
- Detect iframe context and clear fixed heights so parent can size to content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689772dbd16c8323a3d1901637b5e475