### PR TITLE
Fix demo iframe sizing for chatbot and shape analyzer

### DIFF
--- a/css/utilities/layout.css
+++ b/css/utilities/layout.css
@@ -90,18 +90,10 @@
 
 #shapeClassifier-modal .modal-embed,
 #chatbotLora-modal .modal-embed {
-  flex: 0 0 50%;
-  max-width: 50%;
+  flex: 1 1 100%;
+  max-width: 100%;
   align-self: flex-start;
   overflow: visible;
-}
-
-@media (max-width: 768px) {
-  #shapeClassifier-modal .modal-embed,
-  #chatbotLora-modal .modal-embed {
-    flex-basis: 100%;
-    max-width: 100%;
-  }
 }
 
 /* ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expand chatbot and shape analyzer demo iframes to full width so content isn't squished on any device

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689772dbd16c8323a3d1901637b5e475