### PR TITLE
Fix demo layout in iframes

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -41,11 +41,12 @@
         }
 
         html, body {
-            height: 100%;
+            height: auto;
         }
 
         body {
             margin: 0;
+            min-height: 100vh;
             font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
             color: var(--text);
             background: radial-gradient(1200px 500px at 50% -10%, color-mix(in srgb, var(--primary) 15%, transparent), transparent 60%) var(--bg);
@@ -66,12 +67,13 @@
             /* Structure the card so #answer is the only scroller */
             display: grid;
             grid-template-rows: auto auto 1fr auto; /* header, status, chat, input */
-            height: calc(100vh - var(--page-pad) * 2);
+            min-height: calc(100vh - var(--page-pad) * 2);
+            height: auto;
         }
 
         @supports (height: 100dvh) {
             #demo-box {
-                height: calc( 100dvh - var(--page-pad) * 2 - env(safe-area-inset-top) - env(safe-area-inset-bottom) );
+                min-height: calc( 100dvh - var(--page-pad) * 2 - env(safe-area-inset-top) - env(safe-area-inset-bottom) );
             }
         }
 

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -37,11 +37,12 @@
         }
 
         html, body {
-            height: 100%;
+            height: auto;
         }
 
         body {
             margin: 0;
+            min-height: 100vh;
             font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
             color: var(--text);
             background: radial-gradient(1200px 500px at 50% -10%, color-mix(in srgb, var(--primary) 15%, transparent), transparent 60%) var(--bg);
@@ -62,12 +63,13 @@
             /* NEW: let the inner content be the only scroller */
             display: grid;
             grid-template-rows: auto auto 1fr; /* header, status, content */
-            height: calc(100vh - var(--page-pad) * 2);
+            min-height: calc(100vh - var(--page-pad) * 2);
+            height: auto;
         }
 
         @supports (height: 100dvh) {
             #demo-box {
-                height: calc( 100dvh - var(--page-pad)*2 - env(safe-area-inset-top) - env(safe-area-inset-bottom) );
+                min-height: calc( 100dvh - var(--page-pad)*2 - env(safe-area-inset-top) - env(safe-area-inset-bottom) );
             }
         }
 


### PR DESCRIPTION
## Summary
- allow chatbot demo to grow naturally rather than locking to viewport height
- let shape classifier demo expand to its content for better iframe embedding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689777a758ac8323aed49e55e4fce457