### PR TITLE
Refine chatbot modal resizing and mobile text

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -298,11 +298,15 @@
             border-radius: 12px;
             padding: 10px 12px;
             line-height: 1.45;
-            font-size: clamp(.8rem, 2vw, .95rem);
+            font-size: .9rem;
             overflow-wrap: anywhere;
             position: relative;
             box-shadow: var(--shadow-1);
             min-width: 0;
+        }
+
+        @media (max-width: 600px) {
+            .bubble { font-size: .8rem; }
         }
 
             .bubble pre, .bubble code, .bubble table {
@@ -477,7 +481,7 @@
             color: var(--text);
             border-radius: 10px;
             padding: 10px 12px;
-            font-size: clamp(.8rem, 2vw, .95rem);
+            font-size: 1rem;
             line-height: 1.35;
         }
 
@@ -794,7 +798,7 @@
         clearBtn.addEventListener('click', () => {
             answerEl.innerHTML = '';
             localStorage.removeItem('chatbot-demo-history');
-            /* no notifyResize() to avoid iframe jitter */
+            requestAnimationFrame(() => notifyResize());
         });
 
         /* Copy button (event delegation) */
@@ -825,7 +829,7 @@
             const { contentEl, bubble } = appendMessage(wrap, 'bot', '', { loading: true });
             answerEl.appendChild(wrap);
             answerEl.scrollTop = answerEl.scrollHeight;
-            /* no notifyResize() here */
+            notifyResize();
 
             return { contentEl, bubble };
         }
@@ -948,7 +952,7 @@
                 askBtn.disabled = false; stopBtn.hidden = true;
                 form.setAttribute('aria-busy', 'false');
                 saveHistory();
-                /* no notifyResize() to keep iframe static */
+                notifyResize();
             }
         }
 

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -528,8 +528,18 @@ function openModal(id){
       if (!iframe) return;
       try {
         const doc  = iframe.contentDocument || iframe.contentWindow.document;
-        const box  = doc.getElementById('demo-box') || doc.documentElement;
-        iframe.style.height = box.scrollHeight + 'px';
+        const box  = doc.getElementById('demo-box');
+        let height = 0;
+        if (box) {
+          box.style.height = 'auto';
+          height = box.getBoundingClientRect().height;
+        } else {
+          height = Math.max(
+            doc.body?.scrollHeight || 0,
+            doc.documentElement?.scrollHeight || 0
+          );
+        }
+        iframe.style.height = Math.ceil(height) + 10 + 'px';
         iframe.style.width  = '100%';
       } catch (err) {}
     };


### PR DESCRIPTION
## Summary
- adjust chatbot demo font sizing for better mobile legibility
- send resize notifications whenever chatbot content changes so modal iframes fit
- measure embedded demo height more accurately to remove residual scroll bars
- wait a frame before notifying resize on clear and pad measured height for bottom margin
- measure iframe demo container directly to avoid cumulative 10px height growth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c8c88e9c832388f6660e3923a742