### PR TITLE
Enable keyboard interaction for skill links

### DIFF
--- a/js/common/common.js
+++ b/js/common/common.js
@@ -31,8 +31,21 @@
       m.innerHTML=window.generateProjectModal(p);
       modalsRoot.appendChild(m);
     });
-    $$('.skill-link').forEach(btn=>{
-      on(btn,'click',e=>{e.preventDefault();openModal(btn.dataset.project);});
+    $$('.skill-link').forEach(btn => {
+      // Make focusable
+      btn.setAttribute('tabindex','0');
+      // Activate on Enter/Space
+      btn.addEventListener('keydown', ev => {
+        if (ev.key === 'Enter' || ev.key === ' ') {
+          ev.preventDefault();
+          openModal(btn.dataset.project);
+        }
+      });
+      // Click still works
+      on(btn,'click', e => {
+        e.preventDefault();
+        openModal(btn.dataset.project);
+      });
     });
     if(location.hash) openModal(location.hash.slice(1));
   }


### PR DESCRIPTION
## Summary
- Allow `.skill-link` elements to be tabbed to and activated with Enter or Space.

## Testing
- `npm test` *(fails: chatbot-demo warm countdown section missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc8ad4648323b5cfdbb73b60ef30