### PR TITLE
Add SRI to Font Awesome CSS

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,8 +10,17 @@
   <meta property="og:url" content="https://danielshort.me/404.html">
   <meta property="og:image" content="img/hero/head.jpg">
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+  <link rel="preload" as="style"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+        crossorigin="anonymous"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous">
+  </noscript>
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -9,8 +9,17 @@
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Icons & Fonts -->
-    <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+    <link rel="preload" as="style"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous"
+          onload="this.onload=null;this.rel='stylesheet'">
+    <noscript>
+      <link rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+            integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+            crossorigin="anonymous">
+    </noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
@@ -911,7 +920,7 @@
                     : NORMAL_MS;
         }
 
-        // ---- Warm countdown helpers (with smoothing) ----
+        // Warm countdown
         function startWarmClient(initialSec = WARMUP_TARGET_SEC) {
             if (state.warm.active) return;
             state.warm.active = true;
@@ -944,7 +953,7 @@
             if (targetRemaining <= 5 && !state.finishingSince) state.finishingSince = now;
         }
 
-        // ---- Cool-down helpers (with server or local fallback) ----
+        // Cool-down countdown
         function startCoolClient(initialSec = SCALEIN_COOLDOWN_SEC) {
             state.cool.active = true;
             state.cool.startedAt = Date.now();

--- a/contact.html
+++ b/contact.html
@@ -14,8 +14,17 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+  <link rel="preload" as="style"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+        crossorigin="anonymous"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous">
+  </noscript>
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/contributions.html
+++ b/contributions.html
@@ -13,8 +13,17 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+  <link rel="preload" as="style"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+        crossorigin="anonymous"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous">
+  </noscript>
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/index.html
+++ b/index.html
@@ -14,8 +14,17 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+  <link rel="preload" as="style"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+        crossorigin="anonymous"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous">
+  </noscript>
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/portfolio.html
+++ b/portfolio.html
@@ -15,8 +15,17 @@
 
   <!-- styles -->
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+  <link rel="preload" as="style"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+        crossorigin="anonymous"
+        onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous">
+  </noscript>
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -10,8 +10,17 @@
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Icons & Fonts (async, non-blocking) -->
-    <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>
+    <link rel="preload" as="style"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+          crossorigin="anonymous"
+          onload="this.onload=null;this.rel='stylesheet'">
+    <noscript>
+      <link rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+            integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
+            crossorigin="anonymous">
+    </noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
## Summary
- add Subresource Integrity and crossorigin to Font Awesome CSS preload and noscript fallback on all site pages
- adjust chatbot demo countdown comments to align with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c00694f4483239231a00f8cd0ea87