### PR TITLE
Add social meta tags to core pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,6 +9,10 @@
   <meta property="og:description" content="The page you requested could not be found.">
   <meta property="og:url" content="https://danielshort.me/404.html">
   <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
+
   <link rel="stylesheet" href="css/styles.css">
   <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"></noscript>

--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -911,6 +911,7 @@
                     : NORMAL_MS;
         }
 
+        // Warm countdown
         // ---- Warm countdown helpers (with smoothing) ----
         function startWarmClient(initialSec = WARMUP_TARGET_SEC) {
             if (state.warm.active) return;
@@ -944,6 +945,7 @@
             if (targetRemaining <= 5 && !state.finishingSince) state.finishingSince = now;
         }
 
+        // Cool-down countdown
         // ---- Cool-down helpers (with server or local fallback) ----
         function startCoolClient(initialSec = SCALEIN_COOLDOWN_SEC) {
             state.cool.active = true;

--- a/contact.html
+++ b/contact.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="Get in touch with Daniel Short — data analyst &amp; machine-learning practitioner.">
   <meta property="og:url" content="https://danielshort.me/contact.html">
   <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>

--- a/contributions.html
+++ b/contributions.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="Public-facing reports and publications featuring Daniel Short’s data work for Visit Grand Junction.">
   <meta property="og:url" content="https://danielshort.me/contributions.html">
   <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="Daniel Short — data scientist transforming raw numbers into actionable insights.">
   <meta property="og:url" content="https://danielshort.me/">
   <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
 
   <!-- GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>

--- a/portfolio.html
+++ b/portfolio.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="Curated portfolio of data-analytics, ML, and visualization projects by Daniel Short.">
   <meta property="og:url" content="https://danielshort.me/portfolio.html">
   <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
 
   <!-- GA-4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>


### PR DESCRIPTION
## Summary
- add `og:type` and Twitter card meta tags to main HTML pages
- restore warm and cool-down countdown markers in chatbot demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0084d2a08323bcba628fa8501496