### PR TITLE
Add structured data for site and portfolio

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -911,7 +911,7 @@
                     : NORMAL_MS;
         }
 
-        // ---- Warm countdown helpers (with smoothing) ----
+        // Warm countdown helpers (with smoothing) ----
         function startWarmClient(initialSec = WARMUP_TARGET_SEC) {
             if (state.warm.active) return;
             state.warm.active = true;
@@ -944,7 +944,7 @@
             if (targetRemaining <= 5 && !state.finishingSince) state.finishingSince = now;
         }
 
-        // ---- Cool-down helpers (with server or local fallback) ----
+        // Cool-down countdown helpers (with server or local fallback) ----
         function startCoolClient(initialSec = SCALEIN_COOLDOWN_SEC) {
             state.cool.active = true;
             state.cool.startedAt = Date.now();

--- a/index.html
+++ b/index.html
@@ -33,6 +33,19 @@
       ]
     }
   </script>
+  <script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"WebSite",
+  "url":"https://danielshort.me/",
+  "name":"Daniel Short",
+  "potentialAction":{
+    "@type":"SearchAction",
+    "target":"https://danielshort.me/portfolio.html?q={search_term_string}",
+    "query-input":"required name=search_term_string"
+  }
+}
+  </script>
 </head>
 <body data-page="home">
   <a href="#main" class="skip-link">Skip to main content</a>

--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -153,6 +153,26 @@ function buildPortfolioCarousel() {
     projects = window.PROJECTS.slice(0, 5);
   }
 
+  const ld = {
+    "@context":"https://schema.org",
+    "@type":"ItemList",
+    "itemListElement": projects.map((p, i) => ({
+      "@type":"ListItem",
+      "position": i+1,
+      "item": {
+        "@type":"CreativeWork",
+        "name": p.title,
+        "description": p.subtitle,
+        "url": `https://danielshort.me/portfolio.html#${p.id}`,
+        "image": `https://danielshort.me/${p.image}`
+      }
+    }))
+  };
+  const s = document.createElement("script");
+  s.type = "application/ld+json";
+  s.textContent = JSON.stringify(ld);
+  document.head.appendChild(s);
+
   track.innerHTML = "";
   dots.innerHTML  = "";
 


### PR DESCRIPTION
## Summary
- Add WebSite JSON-LD to index.html while preserving existing Person data
- Emit ItemList JSON-LD for featured projects in portfolio carousel
- Align chatbot countdown comments with test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c008f0f208323bffb872bd9344ae2