### PR TITLE
Switch contact modal to active state

### DIFF
--- a/js/forms/contact.js
+++ b/js/forms/contact.js
@@ -18,13 +18,15 @@
 
   function open(){ if(!modal) return;
     prevFocus = document.activeElement;
-    modal.classList.add('open');
+    modal.classList.add('active');
+    document.body.classList.add('modal-open');
     content.setAttribute('tabindex','0');
     content.focus({preventScroll:true});
     content.addEventListener('keydown', trap);
   }
   function close(){ if(!modal) return;
-    modal.classList.remove('open');
+    modal.classList.remove('active');
+    document.body.classList.remove('modal-open');
     content.removeEventListener('keydown', trap);
     if (prevFocus) prevFocus.focus();
   }
@@ -32,5 +34,5 @@
   openBtn && openBtn.addEventListener('click', open);
   closeBtn && closeBtn.addEventListener('click', close);
   modal && modal.addEventListener('click', (e)=>{ if(e.target === modal) close(); });
-  document.addEventListener('keydown', (e)=>{ if(e.key === 'Escape' && modal.classList.contains('open')) close(); });
+  document.addEventListener('keydown', (e)=>{ if(e.key === 'Escape' && modal.classList.contains('active')) close(); });
 })();


### PR DESCRIPTION
## Summary
- Replace modal `open` class with `active` and update Escape key check
- Add/remove `modal-open` class on `<body>` when contact modal toggles

## Testing
- `npm test` *(fails: document.getElementById is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c0800440483238665a580e061071e