### PR TITLE
fix: reset project card buttons for consistent styling

### DIFF
--- a/css/components/projects.css
+++ b/css/components/projects.css
@@ -47,3 +47,33 @@
   aspect-ratio: 16 / 9;
   display: block;
 }
+/* --- Button-card reset to match previous DIV cards --- */
+button.project-card {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  display: block;
+  text-align: left;
+  cursor: pointer;
+}
+
+/* Ensure titles/subtitles stay light & left-aligned */
+.project-card,
+.project-card .project-title,
+.project-card .project-subtitle,
+.carousel-card .project-title,
+.carousel-card .project-subtitle {
+  color: var(--text-light);
+  text-align: left;
+}
+
+/* Overlay should not block clicks */
+.project-card .overlay { pointer-events: none; }
+
+/* Focus visibility for keyboard users */
+.project-card:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- reset button project cards to match div cards
- keep project titles/subtitles light and aligned
- ensure overlay doesn't block clicks and add focus styles

## Testing
- `npm test` *(fails: document.getElementById is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c08057d148323bd4f37e0b72216a7