### PR TITLE
Add delegated modal close handlers

### DIFF
--- a/js/common/common.js
+++ b/js/common/common.js
@@ -53,4 +53,26 @@
   document.addEventListener('DOMContentLoaded', ()=>{
     if (window.buildPortfolio) run(initSkillPopups);
   });
+
+  // ---- Global modal close handlers (X button and backdrop) ----
+  document.addEventListener('click', (e) => {
+    // 1) Close when X is clicked
+    const closeBtn = e.target.closest('.modal-close');
+    if (closeBtn) {
+      e.preventDefault();
+      const modal = closeBtn.closest('.modal');
+      if (modal) {
+        const id = modal.id?.replace(/-modal$/, '') || modal.id || 'modal';
+        window.closeModal && window.closeModal(id);
+      }
+      return;
+    }
+    // 2) Close when clicking the backdrop (outside modal-content)
+    const backdrop = e.target.closest('.modal');
+    const insideContent = e.target.closest('.modal-content');
+    if (backdrop && !insideContent) {
+      const id = backdrop.id?.replace(/-modal$/, '') || backdrop.id || 'modal';
+      window.closeModal && window.closeModal(id);
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- Add delegated global click listener to handle modal closing when clicking X buttons or backdrop outside the modal content

## Testing
- `npm test` *(fails: document.getElementById is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c0b7a8cf88323a1d57451c150981b