### PR TITLE
Add Font Awesome CDN links to all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,21 +14,8 @@
   <meta name="twitter:site" content="@danielshort3">
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -9,21 +9,8 @@
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Icons & Fonts -->
-    <link rel="preload" as="style"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous"
-          onload="this.onload=null;this.rel='stylesheet'">
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-    <noscript>
-      <link rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-            integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-            crossorigin="anonymous">
-    </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/contact.html
+++ b/contact.html
@@ -17,21 +17,8 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/contributions.html
+++ b/contributions.html
@@ -16,21 +16,8 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/index.html
+++ b/index.html
@@ -17,21 +17,8 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
 
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/portfolio.html
+++ b/portfolio.html
@@ -18,21 +18,8 @@
 
   <!-- styles -->
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">

--- a/privacy.html
+++ b/privacy.html
@@ -7,17 +7,8 @@
   <link rel="canonical" href="https://danielshort.me/privacy.html">
   <meta name="description" content="Learn how analytics are used on this site.">
   <link rel="stylesheet" href="css/styles.css">
-  <link rel="preload" as="style"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-        integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-        crossorigin="anonymous"
-        onload="this.onload=null;this.rel='stylesheet'">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-  </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
   <link rel="icon" href="img/ui/logo.png" type="image/png">
 </head>
 <body class="surface-band">

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -10,21 +10,8 @@
     <link rel="stylesheet" href="css/styles.css">
 
     <!-- Icons & Fonts (async, non-blocking) -->
-    <link rel="preload" as="style"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous"
-          onload="this.onload=null;this.rel='stylesheet'">
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-          integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-          crossorigin="anonymous">
-    <noscript>
-      <link rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-            integrity="sha384-yLkiH0IMDs4yTwz/Q7a+Zb6GQTfQ73KhUKXBwIbYe3vu04ujO/Y2ar7Osldd+Gtj"
-            crossorigin="anonymous">
-    </noscript>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@600&display=swap" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
## Summary
- replace async Font Awesome 6.5.0 preload block with straightforward CDN links
- preconnect to cdnjs and load Font Awesome 7.0.0 on every HTML page for reliable icon rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c138846b883238d32802d66bda14e