### PR TITLE
Add privacy links to all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,7 +30,14 @@
     <p>Sorry, the page you were looking for doesn&rsquo;t exist.</p>
     <p><a href="index.html">Return to home page</a></p>
   </main>
-  <footer></footer>
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+        Do Not Sell/Share My Personal Information
+      </a>
+    </nav>
+  </footer>
   <script defer src="js/common/common.js"></script>
   <script defer src="js/navigation/navigation.js"></script>
   <script src="js/privacy/config.js"></script>

--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -1247,6 +1247,14 @@
             update();
         })();
     </script>
+    <footer>
+      <nav class="privacy-links" aria-label="Privacy shortcuts">
+        <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+        <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+          Do Not Sell/Share My Personal Information
+        </a>
+      </nav>
+    </footer>
     <script src="js/privacy/config.js"></script>
     <script defer src="js/privacy/consent_manager.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -72,7 +72,14 @@
     </section>
 
   </main>
-  <footer></footer>
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+        Do Not Sell/Share My Personal Information
+      </a>
+    </nav>
+  </footer>
 
     <script defer src="js/common/common.js"></script>
     <script defer src="js/navigation/navigation.js"></script>

--- a/contributions.html
+++ b/contributions.html
@@ -46,7 +46,14 @@
     <div id="contrib-root"></div>
   </main>
 
-  <footer></footer>
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+        Do Not Sell/Share My Personal Information
+      </a>
+    </nav>
+  </footer>
   <script defer src="js/contributions/contributions-data.js"></script>
   <script defer src="js/contributions/contributions.js"></script>
   <script defer src="js/contributions/carousel.js"></script>

--- a/index.html
+++ b/index.html
@@ -172,7 +172,14 @@
 
   </main>
 
-  <footer></footer>
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+        Do Not Sell/Share My Personal Information
+      </a>
+    </nav>
+  </footer>
   <script defer src="js/common/common.js"></script>
   <script defer src="js/navigation/navigation.js"></script>
   <script defer src="js/animations/animations.js"></script>

--- a/portfolio.html
+++ b/portfolio.html
@@ -85,7 +85,14 @@
 
   <!-- footer is injected by common.js -->
   </main>
-  <footer></footer>
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+        Do Not Sell/Share My Personal Information
+      </a>
+    </nav>
+  </footer>
 
   <!-- scripts -->
   <script defer src="js/common/common.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -125,7 +125,14 @@
         </section>
     </main>
 
-    <footer></footer>
+    <footer>
+        <nav class="privacy-links" aria-label="Privacy shortcuts">
+            <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+            <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+                Do Not Sell/Share My Personal Information
+            </a>
+        </nav>
+    </footer>
 
     <!-- (Optional) GA loader, consistent with other pages that use analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>

--- a/shape-demo.html
+++ b/shape-demo.html
@@ -830,6 +830,14 @@
 
         // (No ResizeObserver-driven notifyResize() to prevent iframe jitter)
     </script>
+    <footer>
+      <nav class="privacy-links" aria-label="Privacy shortcuts">
+        <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+        <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">
+          Do Not Sell/Share My Personal Information
+        </a>
+      </nav>
+    </footer>
     <script src="js/privacy/config.js"></script>
     <script defer src="js/privacy/consent_manager.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add privacy settings and CA Do Not Sell/Share links to every page footer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c2359b450832395e5fa7d00048234