### PR TITLE
Remove direct GA loader tags

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,9 +13,6 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@danielshort3">
 
-  <!-- GA4 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
-
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/privacy.css">
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>

--- a/contributions.html
+++ b/contributions.html
@@ -12,9 +12,6 @@
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@danielshort3">
-
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
-
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/privacy.css">
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -13,9 +13,6 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@danielshort3">
 
-  <!-- GA4 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
-
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/privacy.css">
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>

--- a/portfolio.html
+++ b/portfolio.html
@@ -13,9 +13,6 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@danielshort3">
 
-  <!-- GA-4 -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
-
   <!-- styles -->
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/privacy.css">

--- a/privacy.html
+++ b/privacy.html
@@ -134,9 +134,6 @@
         </nav>
     </footer>
 
-    <!-- (Optional) GA loader, consistent with other pages that use analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0VL37MQ62P"></script>
-
     <!-- Site scripts -->
     <script defer src="js/common/common.js"></script>
     <script defer src="js/navigation/navigation.js"></script>


### PR DESCRIPTION
## Summary
- strip Google Analytics loader scripts from all HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c25107fdc83238c8533b0bd4465eb