### PR TITLE
Add resume preview page and update links

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
         <!-- primary + secondary CTAs -->
         <div class="cta-group">
           <a href="portfolio.html"                        class="btn-secondary hero-cta">Portfolio</a>
-          <a href="documents/Resume.pdf" target="_blank" rel="noopener noreferrer"  class="btn-secondary hero-cta" download>Resume</a>
+          <a href="resume.html" class="btn-secondary hero-cta">Resume</a>
         </div>
       </div>
         <div class="chevron-hint scroll-indicator" aria-hidden="true"><i class="fa-solid fa-chevron-down"></i></div>

--- a/js/navigation/navigation.js
+++ b/js/navigation/navigation.js
@@ -44,7 +44,7 @@
             <a href="portfolio.html" class="btn-secondary nav-link">Portfolio</a>
             <a href="contributions.html" class="btn-secondary nav-link">Contributions</a>
             <a href="contact.html" class="btn-secondary nav-link">Contact</a>
-            <a href="documents/Resume.pdf" class="btn-secondary nav-link" target="_blank" rel="noopener noreferrer" download>Resume</a>
+            <a href="resume.html" class="btn-secondary nav-link">Resume</a>
           </div>
         </div>
       </nav>`;

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resume │ Daniel Short</title>
+  <link rel="canonical" href="https://danielshort.me/resume.html">
+  <meta property="og:title" content="Resume │ Daniel Short">
+  <meta property="og:description" content="Preview and download Daniel Short's resume.">
+  <meta property="og:url" content="https://danielshort.me/resume.html">
+  <meta property="og:image" content="img/hero/head.jpg">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@danielshort3">
+
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/privacy.css">
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
+  <link rel="icon" href="img/ui/logo.png" type="image/png">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Poppins:wght@500;600&display=swap" rel="stylesheet"></noscript>
+  <meta name="description" content="Preview and download Daniel Short's resume.">
+</head>
+<body data-page="resume">
+  <a href="#main" class="skip-link">Skip to main content</a>
+  <header id="combined-header-nav"></header>
+
+  <main id="main">
+    <section class="surface-band">
+      <div class="wrapper">
+        <h1>Resume</h1>
+        <div class="cta-group">
+          <a href="documents/Resume.pdf" class="btn-secondary" download>Download PDF</a>
+        </div>
+        <object data="documents/Resume.pdf" type="application/pdf" width="100%" height="800" aria-label="Resume preview">
+          <p>Your browser does not support embedded PDFs. <a href="documents/Resume.pdf" download>Download the PDF</a>.</p>
+        </object>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <nav class="privacy-links" aria-label="Privacy shortcuts">
+      <button id="privacy-settings-link" type="button" class="pcz-link">Privacy settings</button>
+      <a href="#" class="pcz-link" onclick="window.Privacy && window.Privacy.open('doNotSell'); return false;">Do Not Sell/Share My Personal Information</a>
+    </nav>
+  </footer>
+
+  <script defer src="js/common/common.js"></script>
+  <script defer src="js/navigation/navigation.js"></script>
+  <script defer src="js/animations/animations.js"></script>
+  <script defer src="js/analytics/ga4-events.js"></script>
+  <script src="js/privacy/config.js"></script>
+  <script defer src="js/privacy/consent_manager.js"></script>
+</body>
+</html>
+

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,4 +4,5 @@
   <url><loc>https://danielshort.me/portfolio.html</loc></url>
   <url><loc>https://danielshort.me/contributions.html</loc></url>
   <url><loc>https://danielshort.me/contact.html</loc></url>
+  <url><loc>https://danielshort.me/resume.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- Add dedicated resume page with inline preview and download button
- Update home page and navigation links to point to resume page
- Include resume page in sitemap
- Simplify resume page layout by removing hero section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9205742c832392a8e3db6dfc9d99