### PR TITLE
Auto-open portfolio modal from URL hash

### DIFF
--- a/js/portfolio/portfolio.js
+++ b/js/portfolio/portfolio.js
@@ -592,4 +592,16 @@ function buildPortfolio() {
       }, 450); // height transition duration
     }, 350);   // grid fade duration
   });
+
+  /* ➎ Open modal if a hash is present or changes ------------------- */
+  const openFromHash = () => {
+    const id = location.hash.slice(1);
+    if (!id) return;
+    const modal = document.getElementById(`${id}-modal`);
+    if (modal) openModal(id);
+  };
+
+  // Try to open on initial load and whenever the hash changes
+  openFromHash();
+  window.addEventListener("hashchange", openFromHash);
 }


### PR DESCRIPTION
## Summary
- Open portfolio project modals automatically when a URL hash is present
- Monitor hash changes to trigger the corresponding modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa1c53f388323ba8402f126162c5b