### PR TITLE
Implement client-side server status timers

### DIFF
--- a/chatbot-demo.html
+++ b/chatbot-demo.html
@@ -867,256 +867,121 @@
             parentBubble.appendChild(div);
         }
 
-        /* ---------- Service status (debounced + smoothed + fallbacks) ---------- */
-        // Keep these in sync with approximate observed warmup; server ETA (if present) will override.
-        const WARMUP_TARGET_SEC = 600;       // ~10 minutes default; reconciled by Lambda ETA when available
-        const SCALEIN_COOLDOWN_SEC = 60;     // idle->off window
+        /* ---------- Server status (client-side timers only) ---------- */
+        const START_TIMEOUT_SEC = 600; // 10 minutes fixed
+        const GRACE_SEC = 60;          // 60 second online grace
 
-        // Poll pacing
-        const FAST_MS = 2000;                // while Starting or while timers active
-        const NORMAL_MS = 12000;             // while Off
-        const SLOW_MS = 10000;               // while On (shorter so UI doesn't "stick")
-        const TIMEOUT_MS = 4000;
-
-        // Smoothing/debounce knobs
-        const STATUS_DEBOUNCE_SEC = 6;       // require ~N sec stability before flipping UI state
-        const ETA_SMOOTH_MAX_UP = 10;        // never increase remaining-warm by >10s
-        const FINISH_HOLD_SEC = 90;          // when near the end, hold at ~98% to avoid 0s flapping
-
-        const state = {
-            serverStatus: 'Off',
-            lastAppliedStatus: 'Off',
-            statusBuf: [],
-            statusSince: Date.now(),
-            queue: 0,
-            queueTs: 0,
-            warm: { active: false, startedAt: 0, total: WARMUP_TARGET_SEC },
-            cool: { active: false, startedAt: 0, total: SCALEIN_COOLDOWN_SEC },
-            finishingSince: 0
+        const STATE = {
+            OFFLINE_DETECTED: 'OFFLINE_DETECTED',
+            STARTING: 'STARTING',
+            ONLINE: 'ONLINE',
+            ONLINE_GRACE: 'ONLINE_GRACE',
+            SHUTDOWN: 'SHUTDOWN'
         };
 
+        let currentState = STATE.OFFLINE_DETECTED;
+        let startingTimer = null, startingDeadline = 0;
+        let graceTimer = null, graceDeadline = 0;
+
+        async function checkStatus() {
+            try {
+                const r = await fetch(STATUS_URL, { cache: 'no-store' });
+                const d = await r.json();
+                return !!d.online;
+            } catch {
+                return false;
+            }
+        }
         function setDot(status) {
-            svcDot.className = 'svc-dot ' + (status === 'On' ? 'green' : status === 'Starting' ? 'amber' : 'gray');
+            const cls = status === STATE.ONLINE || status === STATE.ONLINE_GRACE ? 'green'
+                : status === STATE.STARTING ? 'amber' : 'gray';
+            svcDot.className = 'svc-dot ' + cls;
         }
-        function fmtSecs(s) {
-            if (s == null) return '…';
-            s = Math.max(0, Math.round(s));
-            if (s < 60) return `${s}s`;
-            const m = Math.floor(s / 60), sec = s % 60;
-            return `${m}m ${sec}s`;
+        function fmtClock(s) {
+            const m = Math.floor(s / 60);
+            const sec = s % 60;
+            return `${m}:${String(sec).padStart(2, '0')}`;
         }
-        function nextDelay(effectiveStatus) {
-            if (state.warm.active || state.cool.active) return FAST_MS;
-            return effectiveStatus === 'Starting' ? FAST_MS
-                : effectiveStatus === 'On' ? SLOW_MS
-                    : NORMAL_MS;
-        }
-
-        // Warm countdown helpers (with smoothing)
-        function startWarmClient(initialSec = WARMUP_TARGET_SEC) {
-            if (state.warm.active) return;
-            state.warm.active = true;
-            state.warm.startedAt = Date.now();
-            state.warm.total = Math.max(30, initialSec);
-            state.finishingSince = 0;
-        }
-        function stopWarmClient() {
-            state.warm.active = false;
-            state.finishingSince = 0;
-        }
-        function currentWarmRemaining() {
-            if (!state.warm.active) return null;
-            const elapsed = (Date.now() - state.warm.startedAt) / 1000;
-            return Math.max(0, Math.round(state.warm.total - elapsed));
-        }
-        function reconcileWarmFromServer(serverEta) {
-            if (!Number.isFinite(serverEta)) return;
-            if (!state.warm.active) { startWarmClient(Math.max(30, serverEta)); return; }
-
-            const now = Date.now();
-            const elapsed = (now - state.warm.startedAt) / 1000;
-            const remaining = Math.max(0, state.warm.total - elapsed);
-
-            // Never let remaining jump up by more than ETA_SMOOTH_MAX_UP seconds.
-            const allowedUp = Math.min(remaining + ETA_SMOOTH_MAX_UP, serverEta + 3);
-            const targetRemaining = Math.min(remaining, allowedUp);
-
-            state.warm.total = targetRemaining + elapsed;
-            if (targetRemaining <= 5 && !state.finishingSince) state.finishingSince = now;
-        }
-
-        // Cool-down helpers (with server or local fallback)
-        function startCoolClient(initialSec = SCALEIN_COOLDOWN_SEC) {
-            state.cool.active = true;
-            state.cool.startedAt = Date.now();
-            state.cool.total = Math.max(1, initialSec);
-        }
-        function stopCoolClient() { state.cool.active = false; }
-        function currentCoolRemaining() {
-            if (!state.cool.active) return null;
-            const elapsed = (Date.now() - state.cool.startedAt) / 1000;
-            return Math.max(0, Math.round(state.cool.total - elapsed));
-        }
-        function reconcileCoolFromServer(serverEta) {
-            if (!Number.isFinite(serverEta) || serverEta <= 0) {
-                if (!state.cool.active) startCoolClient(SCALEIN_COOLDOWN_SEC);
-                return;
-            }
-            if (!state.cool.active) { startCoolClient(serverEta); return; }
-
-            const elapsed = (Date.now() - state.cool.startedAt) / 1000;
-            const remaining = Math.max(0, state.cool.total - elapsed);
-            const targetRemaining = Math.min(remaining, serverEta + 2, remaining + 5);
-            state.cool.total = targetRemaining + elapsed;
-        }
-
-        // ---- Status debounce (prevents flicker and "stuck On until refresh") ----
-        function applyServerStatus(rawStatus) {
-            const now = Date.now();
-            state.serverStatus = rawStatus || 'Off';
-            state.statusBuf.push({ s: state.serverStatus, t: now });
-            if (state.statusBuf.length > 8) state.statusBuf.shift();
-
-            const cutoff = now - STATUS_DEBOUNCE_SEC * 1000;
-            const recent = state.statusBuf.filter(e => e.t >= cutoff).map(e => e.s);
-
-            let best = state.lastAppliedStatus, bestCount = 0;
-            ['Off', 'Starting', 'On'].forEach(s => {
-                const c = recent.filter(x => x === s).length;
-                if (c > bestCount) { best = s; bestCount = c; }
-            });
-
-            if (best !== state.lastAppliedStatus) {
-                state.lastAppliedStatus = best;
-                state.statusSince = now;
-
-                if (best === 'Starting' && !state.warm.active) startWarmClient(WARMUP_TARGET_SEC);
-                if (best !== 'Starting') stopWarmClient();
-
-                if (best === 'On' && !state.cool.active) startCoolClient(SCALEIN_COOLDOWN_SEC);
-                if (best !== 'On') stopCoolClient();
-            }
-        }
-
-        // ---- Button copy tweaks ----
-        const defaultAskHTML = askBtn.innerHTML;
-        function updateAskButton(effectiveStatus) {
-            if (effectiveStatus === 'Off') {
-                askBtn.innerHTML = '<i class="fa-solid fa-bolt"></i> Send &amp; Wake';
-                askBtn.title = 'Wakes the server (~10 min for first reply)';
-            } else if (effectiveStatus === 'Starting') {
-                askBtn.innerHTML = '<i class="fa-solid fa-hourglass-half"></i> Join Queue';
-                askBtn.title = 'Your message will queue while the server warms';
+        async function initStatus() {
+            const online = await checkStatus();
+            if (online) {
+                currentState = STATE.ONLINE;
+                setDot(currentState);
+                svcText.textContent = 'Server is online.';
+                svcETA.textContent = '';
             } else {
-                askBtn.innerHTML = defaultAskHTML;
-                askBtn.title = '';
+                currentState = STATE.OFFLINE_DETECTED;
+                setDot(currentState);
+                svcText.textContent = 'Server is offline.';
+                svcETA.textContent = '';
             }
         }
+        initStatus();
 
-        // ---- Render status bar once per second ----
-        function renderStatusBar() {
-            const effectiveStatus = state.warm.active ? 'Starting' : state.lastAppliedStatus;
-            setDot(effectiveStatus);
-            updateAskButton(effectiveStatus);
-
-            let line = effectiveStatus;
-
-            // Warm progress (with finishing hold)
-            if (effectiveStatus === 'Starting') {
-                const rem = currentWarmRemaining();
-                if (rem != null) {
-                    const inHold = state.finishingSince && ((Date.now() - state.finishingSince) / 1000) < FINISH_HOLD_SEC;
-                    const elapsed = (Date.now() - state.warm.startedAt) / 1000;
-                    const pct = inHold ? 98 : Math.max(0, Math.min(100, (elapsed / Math.max(1, state.warm.total)) * 100));
-
-                    line = inHold ? 'Starting (finishing…)' : `Starting (~${fmtSecs(rem)})`;
-                    svcProg.hidden = false; svcFill.style.width = `${pct}%`;
-                } else {
-                    svcProg.hidden = true; svcFill.style.width = '0%';
-                }
-            } else {
-                svcProg.hidden = true; svcFill.style.width = '0%';
-            }
-
-            // Cool-down ETA while On
-            if (effectiveStatus === 'On') {
-                const cool = currentCoolRemaining();
-                if (cool != null && cool > 0) line += ` (idle→off ~${fmtSecs(cool)})`;
-            }
-
-            svcText.textContent = line;
-
-            // Queue (hide if stale)
-            const stalenessMs = Date.now() - (state.queueTs || 0);
-            if (Number(state.queue) > 0 && stalenessMs < 120000) {
-                svcQueueWrap.hidden = false; svcQ.textContent = String(state.queue);
-            } else {
-                svcQueueWrap.hidden = true;
-            }
-
-            // Safety: stop forcing warm if stuck far beyond target
-            if (state.warm.active) {
-                const elapsed = (Date.now() - state.warm.startedAt) / 1000;
-                const guard = Math.max(state.warm.total, WARMUP_TARGET_SEC) + 30;
-                if (elapsed > guard) stopWarmClient();
+        // Starting timer helpers
+        function startStartingTimer() {
+            if (startingTimer) return;
+            currentState = STATE.STARTING;
+            setDot(currentState);
+            svcText.textContent = 'Server is starting (up to ~10 minutes).';
+            startingDeadline = Date.now() + START_TIMEOUT_SEC * 1000;
+            updateStarting();
+            startingTimer = setInterval(updateStarting, 1000);
+        }
+        function updateStarting() {
+            const remaining = Math.max(0, Math.round((startingDeadline - Date.now()) / 1000));
+            svcETA.textContent = fmtClock(remaining);
+            if (remaining <= 0) {
+                clearInterval(startingTimer);
+                startingTimer = null;
+                svcText.textContent = 'Server start is taking longer than expected.';
+                startGraceCycle();
             }
         }
-        setInterval(renderStatusBar, 1000);
-
-        // ---- Network poll ----
-        let pollTimer = null, backoff = 0;
-        function schedule(ms) { if (pollTimer) clearTimeout(pollTimer); pollTimer = setTimeout(pollStatus, ms); }
-
-        async function fetchWithTimeout(url, ms) {
-            const ctl = new AbortController(); const t = setTimeout(() => ctl.abort(), ms);
-            try {
-                const r = await fetch(url, { cache: 'no-store', signal: ctl.signal });
-                if (!r.ok) throw new Error(`HTTP ${r.status}`);
-                return await r.json();
-            } finally { clearTimeout(t); }
+        function currentStartingRemaining() {
+            if (!startingTimer) return null;
+            return Math.max(0, Math.round((startingDeadline - Date.now()) / 1000));
         }
+        // End starting timer helpers
 
-        async function pollStatus() {
-            if (document.hidden) { schedule(SLOW_MS); return; }
-            try {
-                const data = await fetchWithTimeout(STATUS_URL, TIMEOUT_MS);
-
-                // 1) Debounce status
-                applyServerStatus(data.status || 'Off');
-
-                // 2) Warm/cool ETAs
-                const warmEta = Number(data?.eta?.to_warm_seconds);
-                const coolEta = Number(data?.eta?.to_scale_to_zero_seconds);
-                if (state.lastAppliedStatus === 'Starting') reconcileWarmFromServer(Number.isFinite(warmEta) ? warmEta : undefined);
-                if (state.lastAppliedStatus === 'On') reconcileCoolFromServer(Number.isFinite(coolEta) ? coolEta : undefined);
-
-                // 3) Queue + staleness and gentle decay if metrics go quiet
-                const q = Number(data.queue_estimate || 0);
-                if (Number.isFinite(q)) { state.queue = Math.max(0, Math.round(q)); state.queueTs = Date.now(); }
-                else {
-                    const age = Date.now() - (state.queueTs || 0);
-                    if (age > 90000 && state.queue > 0 && (Math.floor(age / 30000) > 0)) {
-                        state.queue = Math.max(0, state.queue - 1);
+        // Grace period helpers
+        function startGraceCycle() {
+            currentState = STATE.ONLINE_GRACE;
+            setDot(currentState);
+            svcText.textContent = 'Server is online. A 60-second timeout is active.';
+            graceDeadline = Date.now() + GRACE_SEC * 1000;
+            updateGrace();
+            graceTimer = setInterval(updateGrace, 1000);
+        }
+        function updateGrace() {
+            const remaining = Math.max(0, Math.round((graceDeadline - Date.now()) / 1000));
+            svcETA.textContent = fmtClock(remaining);
+            if (remaining <= 0) {
+                clearInterval(graceTimer);
+                graceTimer = null;
+                checkStatus().then(online => {
+                    if (!online) {
+                        currentState = STATE.SHUTDOWN;
+                        setDot(currentState);
+                        svcText.textContent = 'Server has shut down. Send a message to start it again.';
+                        svcETA.textContent = '';
+                    } else {
+                        currentState = STATE.ONLINE;
+                        setDot(currentState);
+                        svcText.textContent = 'Server is online.';
+                        svcETA.textContent = '';
+                        setTimeout(startGraceCycle, 0);
                     }
-                }
-
-                renderStatusBar();
-                backoff = 0;
-
-                const eff = state.warm.active ? 'Starting' : state.lastAppliedStatus;
-                const baseDelay = nextDelay(eff);
-                const extraFast = (state.queue > 0 || state.cool.active || state.warm.active) ? FAST_MS : baseDelay;
-                schedule(extraFast);
-
-            } catch (e) {
-                renderStatusBar();
-                backoff = Math.min(4, backoff + 1);
-                schedule(NORMAL_MS * backoff);
+                }).catch(() => {
+                    setTimeout(startGraceCycle, 0);
+                });
             }
         }
-        document.addEventListener('visibilitychange', () => { if (!document.hidden) pollStatus(); });
-        pollStatus();
+        // End grace period helpers
 
+        function onFirstUserRequest() {
+            if (currentState === STATE.OFFLINE_DETECTED) startStartingTimer();
+        }
         /* ---------- Networking ---------- */
         let abort = null; let cancelled = false;
         async function ask(prompt, onStatus = () => { }) {
@@ -1131,9 +996,7 @@
 
             const outputUri = submit.outputUri;
 
-            // Show "Processing" now + start warm countdown instantly
             onStatus('PENDING');
-            startWarmClient(WARMUP_TARGET_SEC);
 
             async function poll() {
                 if (cancelled) throw new Error('stopped');
@@ -1156,6 +1019,7 @@
         async function handleSubmit(e) {
             if (e) e.preventDefault();
             const prompt = promptEl.value.trim(); if (!prompt) return;
+            onFirstUserRequest();
             setStep('submit', 'in-progress'); askBtn.disabled = true; stopBtn.hidden = false; form.setAttribute('aria-busy', 'true');
             const { contentEl, bubble } = createExchange(prompt);
             promptEl.value = ''; autoResize();
@@ -1166,16 +1030,6 @@
                         setStep('submit', 'done'); setStep('process', 'in-progress');
                     } else if (status === 'READY') {
                         setStep('process', 'done'); setStep('complete', 'done');
-
-                        // Reply is ready: clear warm banner and kick off local cool-down immediately.
-                        stopWarmClient();
-                        startCoolClient(SCALEIN_COOLDOWN_SEC);
-
-                        // Sync quickly with server ETA if available.
-                        try { pollStatus(); } catch { }
-                    } else if (status === 'FAILED') {
-                        // Ensure warm banner clears on failure too
-                        stopWarmClient();
                     }
                 });
                 contentEl.innerHTML = renderMarkdown(data.generated_text || JSON.stringify(data));


### PR DESCRIPTION
## Summary
- replace complex service polling with simple client-side status state machine
- add 10-minute startup and 60-second grace countdowns
- adjust tests for new startup timer helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61d3a17108323a6a2d98ebad5dbe7